### PR TITLE
Renamed DataTypeDefined to DataTypeContainer

### DIFF
--- a/sources/lusan/common/XmlSI.hpp
+++ b/sources/lusan/common/XmlSI.hpp
@@ -71,12 +71,40 @@ namespace XmlSI
     constexpr const char* const xmlSIAttributeValues        { "Values" };
     constexpr const char* const xmlSIAttributeVersion       { "Version" };
     
-
-    constexpr const char* const xmlSIValuePrimitive         { "Primitive" };
-    constexpr const char* const xmlSIValueBasic             { "Basic" };
-    constexpr const char* const xmlSIValueContainer         { "Container" };
     constexpr const char* const xmlSIValueTrue              { "true" };
     constexpr const char* const xmlSIValueFalse             { "false" };
+
+    constexpr const char* const xmlSIValuePrimitive         { "Primitive" };
+    constexpr const char* const xmlSIValueBool              { "bool" };
+    constexpr const char* const xmlSIValueChar              { "char" };
+    constexpr const char* const xmlSIValueUint8             { "uint8" };
+    constexpr const char* const xmlSIValueInt16             { "int16" };
+    constexpr const char* const xmlSIValueUint16            { "uint16" };
+    constexpr const char* const xmlSIValueInt32             { "int32" };
+    constexpr const char* const xmlSIValueUint32            { "uint32" };
+    constexpr const char* const xmlSIValueInt64             { "int64" };
+    constexpr const char* const xmlSIValueUint64            { "uint64" };
+    constexpr const char* const xmlSIValueFloat             { "float" };
+    constexpr const char* const xmlSIValueDouble            { "double" };
+
+    constexpr const char* const xmlSIValueBasicObject       { "BasicObject" };
+    constexpr const char* const xmlSIValueString            { "String" };
+    constexpr const char* const xmlSIValueBinary            { "BinaryBuffer" };
+    constexpr const char* const xmlSIValueDateTime          { "DateTime" };
+
+    constexpr const char* const xmlSIValueBasicContainer    { "BasicContainer" };
+    constexpr const char* const xmlSIValueArray             { "Array" };
+    constexpr const char* const xmlSIValueLinkedList        { "LinkedList" };
+    constexpr const char* const xmlSIValueHashMap           { "HashMap" };
+    constexpr const char* const xmlSIValueMap               { "Map" };
+    constexpr const char* const xmlSIValuePair              { "Pair" };
+    constexpr const char* const xmlSIValueNewType           { "NewType" };
+
+    constexpr const char* const xmlSIValueStructure         { "Structure" };
+    constexpr const char* const xmlSIValueEnumeration       { "Enumeration" };
+    constexpr const char* const xmlSIValueImported          { "Imported" };
+    constexpr const char* const xmlSIValueContainer         { "Container" };
+
 
     constexpr const unsigned int xmlElementId               { 50u };
 }

--- a/sources/lusan/data/common/CMakeLists.txt
+++ b/sources/lusan/data/common/CMakeLists.txt
@@ -4,7 +4,7 @@ list(APPEND LUSAN_SRC
     ${LUSAN}/data/common/DataTypeBase.cpp
     ${LUSAN}/data/common/DataTypeBasic.cpp
     ${LUSAN}/data/common/DataTypeCustom.cpp
-    ${LUSAN}/data/common/DataTypeDefined.cpp
+    ${LUSAN}/data/common/DataTypeContainer.cpp
     ${LUSAN}/data/common/DataTypeEnum.cpp
     ${LUSAN}/data/common/DataTypeFactory.cpp
     ${LUSAN}/data/common/DataTypeImported.cpp
@@ -26,7 +26,7 @@ list(APPEND LUSAN_HDR
     ${LUSAN}/data/common/DataTypeBase.hpp
     ${LUSAN}/data/common/DataTypeBasic.hpp
     ${LUSAN}/data/common/DataTypeCustom.hpp
-    ${LUSAN}/data/common/DataTypeDefined.hpp
+    ${LUSAN}/data/common/DataTypeContainer.hpp
     ${LUSAN}/data/common/DataTypeEnum.hpp
     ${LUSAN}/data/common/DataTypeFactory.hpp
     ${LUSAN}/data/common/DataTypeImported.hpp

--- a/sources/lusan/data/common/DataTypeBase.hpp
+++ b/sources/lusan/data/common/DataTypeBase.hpp
@@ -47,7 +47,7 @@ public:
         , PrimitiveFloat= 0x000C    //!< bits: 0000 0000 0000 1100, Primitive digit with floating point
         , BasicObject   = 0x0010    //!< bits: 0000 0000 0001 0000, Basic object
         , BasicContainer= 0x0020    //!< bits: 0000 0000 0010 0001, Basic container
-        , CustomDefined = 0x0100    //!< bits: 0000 0001 0000 0000, Custom type enumeration
+        , CustomDefined = 0x0100    //!< bits: 0000 0001 0000 0000, Custom type basic
         , Enumeration   = 0x0300    //!< bits: 0000 0011 0000 0000, Custom type enumeration
         , Structure     = 0x0500    //!< bits: 0000 0101 0000 0000, Custom type structure
         , Imported      = 0x0900    //!< bits: 0000 1001 0000 0000, Custom type imported

--- a/sources/lusan/data/common/DataTypeContainer.cpp
+++ b/sources/lusan/data/common/DataTypeContainer.cpp
@@ -10,19 +10,19 @@
  *  with this distribution or contact us at info[at]aregtech.com.
  *
  *  \copyright   © 2023-2024 Aregtech UG. All rights reserved.
- *  \file        lusan/data/common/DataTypeDefined.cpp
+ *  \file        lusan/data/common/DataTypeContainer.cpp
  *  \ingroup     Lusan - GUI Tool for AREG SDK
  *  \author      Artak Avetyan
- *  \brief       Lusan application, Defined Data Type.
+ *  \brief       Lusan application, Container Data Type.
  *
  ************************************************************************/
-#include "lusan/data/common/DataTypeDefined.hpp"
+#include "lusan/data/common/DataTypeContainer.hpp"
 #include "lusan/data/common/DataTypeBasic.hpp"
 #include "lusan/data/common/DataTypeFactory.hpp"
 
 #include "lusan/common/XmlSI.hpp"
 
-DataTypeDefined::DataTypeDefined(ElementBase* parent /*= nullptr*/)
+DataTypeContainer::DataTypeContainer(ElementBase* parent /*= nullptr*/)
     : DataTypeCustom(eCategory::Container, parent)
     , mContainer    ( )
     , mValue( )
@@ -30,7 +30,7 @@ DataTypeDefined::DataTypeDefined(ElementBase* parent /*= nullptr*/)
 {
 }
 
-DataTypeDefined::DataTypeDefined(const QString& name, ElementBase* parent /*= nullptr*/)
+DataTypeContainer::DataTypeContainer(const QString& name, ElementBase* parent /*= nullptr*/)
     : DataTypeCustom(eCategory::Container, 0, name, parent)
     , mContainer    ( )
     , mValue( )
@@ -38,7 +38,7 @@ DataTypeDefined::DataTypeDefined(const QString& name, ElementBase* parent /*= nu
 {
 }
 
-DataTypeDefined::DataTypeDefined(const DataTypeDefined& src)
+DataTypeContainer::DataTypeContainer(const DataTypeContainer& src)
     : DataTypeCustom(src)
     , mContainer    (src.mContainer)
     , mValue(src.mValue)
@@ -46,7 +46,7 @@ DataTypeDefined::DataTypeDefined(const DataTypeDefined& src)
 {
 }
 
-DataTypeDefined::DataTypeDefined(DataTypeDefined&& src) noexcept
+DataTypeContainer::DataTypeContainer(DataTypeContainer&& src) noexcept
     : DataTypeCustom(std::move(src))
     , mContainer(std::move(src.mContainer))
     , mValue    (std::move(src.mValue))
@@ -54,7 +54,7 @@ DataTypeDefined::DataTypeDefined(DataTypeDefined&& src) noexcept
 {
 }
 
-DataTypeDefined& DataTypeDefined::operator = (const DataTypeDefined& other)
+DataTypeContainer& DataTypeContainer::operator = (const DataTypeContainer& other)
 {
     if (this != &other)
     {
@@ -67,7 +67,7 @@ DataTypeDefined& DataTypeDefined::operator = (const DataTypeDefined& other)
     return *this;
 }
 
-DataTypeDefined& DataTypeDefined::operator = (DataTypeDefined&& other) noexcept
+DataTypeContainer& DataTypeContainer::operator = (DataTypeContainer&& other) noexcept
 {
     if (this != &other)
     {
@@ -80,7 +80,7 @@ DataTypeDefined& DataTypeDefined::operator = (DataTypeDefined&& other) noexcept
     return *this;
 }
 
-bool DataTypeDefined::readFromXml(QXmlStreamReader& xml)
+bool DataTypeContainer::readFromXml(QXmlStreamReader& xml)
 {
     if (xml.tokenType() != QXmlStreamReader::StartElement || xml.name() != XmlSI::xmlSIElementDataType)
         return false;
@@ -117,7 +117,7 @@ bool DataTypeDefined::readFromXml(QXmlStreamReader& xml)
     return true;
 }
 
-void DataTypeDefined::writeToXml(QXmlStreamWriter& xml) const
+void DataTypeContainer::writeToXml(QXmlStreamWriter& xml) const
 {
     xml.writeStartElement(XmlSI::xmlSIElementDataType);
     xml.writeAttribute(XmlSI::xmlSIAttributeID, QString::number(getId()));
@@ -135,7 +135,7 @@ void DataTypeDefined::writeToXml(QXmlStreamWriter& xml) const
     xml.writeEndElement(); // DataType
 }
 
-bool DataTypeDefined::canHaveKey(void) const
+bool DataTypeContainer::canHaveKey(void) const
 {
     bool result{ false };
     const QList<DataTypeBasicContainer*> containerTypes = DataTypeFactory::getContainerTypes();

--- a/sources/lusan/data/common/DataTypeContainer.hpp
+++ b/sources/lusan/data/common/DataTypeContainer.hpp
@@ -1,5 +1,5 @@
-#ifndef LUSAN_DATA_COMMON_DATATYPEDEFINED_HPP
-#define LUSAN_DATA_COMMON_DATATYPEDEFINED_HPP
+#ifndef LUSAN_DATA_COMMON_DATATYPECONTAINER_HPP
+#define LUSAN_DATA_COMMON_DATATYPECONTAINER_HPP
 /************************************************************************
  *  This file is part of the Lusan project, an official component of the AREG SDK.
  *  Lusan is a graphical user interface (GUI) tool designed to support the development,
@@ -12,20 +12,20 @@
  *  with this distribution or contact us at info[at]aregtech.com.
  *
  *  \copyright   © 2023-2024 Aregtech UG. All rights reserved.
- *  \file        lusan/data/common/DataTypeDefined.hpp
+ *  \file        lusan/data/common/DataTypeContainer.hpp
  *  \ingroup     Lusan - GUI Tool for AREG SDK
  *  \author      Artak Avetyan
- *  \brief       Lusan application, Defined Data Type.
+ *  \brief       Lusan application, Container Data Type.
  *
  ************************************************************************/
 
 #include "lusan/data/common/DataTypeCustom.hpp"
 
 /**
- * \class   DataTypeDefined
- * \brief   Represents a defined data type in the Lusan application.
+ * \class   DataTypeContainer
+ * \brief   Represents a Container data type in the Lusan application.
  **/
-class DataTypeDefined : public DataTypeCustom
+class DataTypeContainer : public DataTypeCustom
 {
 //////////////////////////////////////////////////////////////////////////
 // Constructors
@@ -34,25 +34,25 @@ public:
     /**
      * \brief   Default constructor.
      **/
-    DataTypeDefined(ElementBase* parent = nullptr);
+    DataTypeContainer(ElementBase* parent = nullptr);
 
     /**
      * \brief   Constructor with name initialization.
      * \param   name    The name of the data type.
      **/
-    DataTypeDefined(const QString& name, ElementBase* parent = nullptr);
+    DataTypeContainer(const QString& name, ElementBase* parent = nullptr);
 
     /**
      * \brief   Copy constructor.
      * \param   src     The source object to copy from.
      **/
-    DataTypeDefined(const DataTypeDefined& src);
+    DataTypeContainer(const DataTypeContainer& src);
 
     /**
      * \brief   Move constructor.
      * \param   src     The source object to move from.
      **/
-    DataTypeDefined(DataTypeDefined&& src) noexcept;
+    DataTypeContainer(DataTypeContainer&& src) noexcept;
 
 //////////////////////////////////////////////////////////////////////////
 // Operators
@@ -64,14 +64,14 @@ public:
      * \param   other   The other object to copy from.
      * \return  Reference to this object.
      **/
-    DataTypeDefined& operator = (const DataTypeDefined& other);
+    DataTypeContainer& operator = (const DataTypeContainer& other);
 
     /**
      * \brief   Move assignment operator.
      * \param   other   The other object to move from.
      * \return  Reference to this object.
      **/
-    DataTypeDefined& operator = (DataTypeDefined&& other) noexcept;
+    DataTypeContainer& operator = (DataTypeContainer&& other) noexcept;
 
 //////////////////////////////////////////////////////////////////////////
 // Attributes, operations and overrides
@@ -115,42 +115,42 @@ private:
 };
 
 //////////////////////////////////////////////////////////////////////////
-// DataTypeDefined class inline methods
+// DataTypeContainer class inline methods
 //////////////////////////////////////////////////////////////////////////
 
-inline const QString& DataTypeDefined::getContainer(void) const
+inline const QString& DataTypeContainer::getContainer(void) const
 {
     return mContainer;
 }
 
-inline void DataTypeDefined::setContainer(const QString& valContainer)
+inline void DataTypeContainer::setContainer(const QString& valContainer)
 {
     mContainer = valContainer;
 }
 
-inline bool DataTypeDefined::hasKey(void) const
+inline bool DataTypeContainer::hasKey(void) const
 {
     return mKey.isEmpty() == false;
 }
 
-inline const QString& DataTypeDefined::getKey(void) const
+inline const QString& DataTypeContainer::getKey(void) const
 {
     return mKey;
 }
 
-inline void DataTypeDefined::setKey(const QString& key)
+inline void DataTypeContainer::setKey(const QString& key)
 {
     mKey = key;
 }
 
-inline const QString& DataTypeDefined::getValue(void) const
+inline const QString& DataTypeContainer::getValue(void) const
 {
     return mValue;
 }
 
-inline void DataTypeDefined::setValue(const QString& value)
+inline void DataTypeContainer::setValue(const QString& value)
 {
     mValue = value;
 }
 
-#endif // LUSAN_DATA_COMMON_DATATYPEDEFINED_HPP
+#endif // LUSAN_DATA_COMMON_DATATYPECONTAINER_HPP

--- a/sources/lusan/data/common/DataTypeCustom.cpp
+++ b/sources/lusan/data/common/DataTypeCustom.cpp
@@ -17,6 +17,7 @@
  *
  ************************************************************************/
 #include "lusan/data/common/DataTypeCustom.hpp"
+#include "lusan/common/XmlSI.hpp"
 
 DataTypeCustom::DataTypeCustom(ElementBase * parent /*= nullptr*/)
     : DataTypeBase(eCategory::CustomDefined, "", 0, parent)
@@ -130,13 +131,13 @@ QString DataTypeCustom::getType(DataTypeBase::eCategory category)
     switch (category)
     {
     case DataTypeBase::eCategory::Enumeration:
-        return "Enumerate";
+        return XmlSI::xmlSIValueEnumeration;
     case DataTypeBase::eCategory::Structure:
-        return "Structure";
+        return XmlSI::xmlSIValueStructure;
     case DataTypeBase::eCategory::Imported:
-        return "Imported";
+        return XmlSI::xmlSIValueImported;
     case DataTypeBase::eCategory::Container:
-        return "DefinedType";
+        return XmlSI::xmlSIValueContainer;
     default:
         return "";
     }
@@ -144,19 +145,19 @@ QString DataTypeCustom::getType(DataTypeBase::eCategory category)
 
 DataTypeBase::eCategory DataTypeCustom::fromTypeString(const QString& type)
 {
-    if (type == "Enumerate")
+    if (type == XmlSI::xmlSIValueEnumeration)
     {
         return DataTypeBase::eCategory::Enumeration;
     }
-    else if (type == "Structure")
+    else if (type == XmlSI::xmlSIValueStructure)
     {
         return DataTypeBase::eCategory::Structure;
     }
-    else if (type == "Imported")
+    else if (type == XmlSI::xmlSIValueImported)
     {
         return DataTypeBase::eCategory::Imported;
     }
-    else if (type == "DefinedType")
+    else if (type == XmlSI::xmlSIValueContainer)
     {
         return DataTypeBase::eCategory::Container;
     }

--- a/sources/lusan/data/common/DataTypeFactory.cpp
+++ b/sources/lusan/data/common/DataTypeFactory.cpp
@@ -21,7 +21,7 @@
 
 #include "lusan/common/XmlSI.hpp"
 #include "lusan/data/common/DataTypeBasic.hpp"
-#include "lusan/data/common/DataTypeDefined.hpp"
+#include "lusan/data/common/DataTypeContainer.hpp"
 #include "lusan/data/common/DataTypeEnum.hpp"
 #include "lusan/data/common/DataTypeImported.hpp"
 #include "lusan/data/common/DataTypePrimitive.hpp"
@@ -37,53 +37,53 @@ QList<DataTypeBasicContainer*>  DataTypeFactory::mPredefinedContainerTypes;   //
 
 DataTypeBase::eCategory DataTypeFactory::fromString(const QString& dataType)
 {
-    if (dataType == TypeNameBool)
+    if (dataType == XmlSI::xmlSIValueBool)
         return DataTypeBase::eCategory::Primitive;
-    else if (dataType == TypeNameChar)
+    else if (dataType == XmlSI::xmlSIValueChar)
         return DataTypeBase::eCategory::PrimitiveSint;
-    else if (dataType == TypeNameUint8)
+    else if (dataType == XmlSI::xmlSIValueUint8)
         return DataTypeBase::eCategory::PrimitiveUint;
-    else if (dataType == TypeNameInt16)
+    else if (dataType == XmlSI::xmlSIValueInt16)
         return DataTypeBase::eCategory::PrimitiveSint;
-    else if (dataType == TypeNameUint16)
+    else if (dataType == XmlSI::xmlSIValueUint16)
         return DataTypeBase::eCategory::PrimitiveUint;
-    else if (dataType == TypeNameInt32)
+    else if (dataType == XmlSI::xmlSIValueInt32)
         return DataTypeBase::eCategory::PrimitiveUint;
-    else if (dataType == TypeNameUint32)
+    else if (dataType == XmlSI::xmlSIValueUint32)
         return DataTypeBase::eCategory::PrimitiveSint;
-    else if (dataType == TypeNameInt64)
+    else if (dataType == XmlSI::xmlSIValueInt64)
         return DataTypeBase::eCategory::PrimitiveSint;
-    else if (dataType == TypeNameUint64)
+    else if (dataType == XmlSI::xmlSIValueUint64)
         return DataTypeBase::eCategory::PrimitiveUint;
-    else if (dataType == TypeNameFloat)
+    else if (dataType == XmlSI::xmlSIValueFloat)
         return DataTypeBase::eCategory::PrimitiveFloat;
-    else if (dataType == TypeNameDouble)
+    else if (dataType == XmlSI::xmlSIValueDouble)
         return DataTypeBase::eCategory::PrimitiveFloat;
-    else if (dataType == TypeNameString)
+    else if (dataType == XmlSI::xmlSIValueString)
         return DataTypeBase::eCategory::BasicObject;
-    else if (dataType == TypeNameBinary)
+    else if (dataType == XmlSI::xmlSIValueBinary)
         return DataTypeBase::eCategory::BasicObject;
-    else if (dataType == TypeNameDateTime)
+    else if (dataType == XmlSI::xmlSIValueDateTime)
         return DataTypeBase::eCategory::BasicObject;
-    else if (dataType == TypeNameArray)
+    else if (dataType == XmlSI::xmlSIValueArray)
         return DataTypeBase::eCategory::BasicContainer;
-    else if (dataType == TypeNameLinkedList)
+    else if (dataType == XmlSI::xmlSIValueLinkedList)
         return DataTypeBase::eCategory::BasicContainer;
-    else if (dataType == TypeNameHashMap)
+    else if (dataType == XmlSI::xmlSIValueHashMap)
         return DataTypeBase::eCategory::BasicContainer;
-    else if (dataType == TypeNameMap)
+    else if (dataType == XmlSI::xmlSIValueMap)
         return DataTypeBase::eCategory::BasicContainer;
-    else if (dataType == TypeNamePair)
+    else if (dataType == XmlSI::xmlSIValuePair)
         return DataTypeBase::eCategory::BasicContainer;
-    else if (dataType == TypeNameNewType)
+    else if (dataType == XmlSI::xmlSIValueNewType)
         return DataTypeBase::eCategory::BasicContainer;
-    else if (dataType == TypeNameEnumerate)
+    else if (dataType == XmlSI::xmlSIValueEnumeration)
         return DataTypeBase::eCategory::Enumeration;
-    else if (dataType == TypeNameStructure)
+    else if (dataType == XmlSI::xmlSIValueStructure)
         return DataTypeBase::eCategory::Structure;
-    else if (dataType == TypeNameImported)
+    else if (dataType == XmlSI::xmlSIValueImported)
         return DataTypeBase::eCategory::Imported;
-    else if (dataType == TypeNameDefined)
+    else if (dataType == XmlSI::xmlSIValueContainer)
         return DataTypeBase::eCategory::Container;
     else
         return DataTypeBase::eCategory::Undefined;
@@ -140,7 +140,7 @@ DataTypeCustom* DataTypeFactory::createCustomDataType(DataTypeBase::eCategory ca
     case DataTypeBase::eCategory::Imported:
         return new DataTypeImported();
     case DataTypeBase::eCategory::Container:
-        return new DataTypeDefined();
+        return new DataTypeContainer();
     default:
         return nullptr;
     }
@@ -218,6 +218,11 @@ int DataTypeFactory::getPredefinedTypes(QList<DataTypeBase *>& result, const QLi
             break;
         }
     }
+
+    std::sort(result.begin() + initCount, result.end(), [](const DataTypeBase* lhs, const DataTypeBase* rhs) -> bool
+        {
+            return lhs->getId() < rhs->getId();
+        });
     
     return static_cast<int>(result.size()) - initCount;
 }
@@ -257,11 +262,11 @@ void DataTypeFactory::_initPredefined(void)
                 {
                     mPredefinePrimitiveTypes.append(static_cast<DataTypePrimitive*>(dataType));
                 }
-                else if (typeName == XmlSI::xmlSIValueBasic)
+                else if (typeName == XmlSI::xmlSIValueBasicObject)
                 {
                     mPredefinedBasicTypes.append(static_cast<DataTypeBasicObject*>(dataType));
                 }
-                else if (typeName == XmlSI::xmlSIValueContainer)
+                else if (typeName == XmlSI::xmlSIValueBasicContainer)
                 {
                     Q_ASSERT(hasValue);
                     DataTypeBasicContainer* container = static_cast<DataTypeBasicContainer*>(dataType);

--- a/sources/lusan/data/common/DataTypeFactory.hpp
+++ b/sources/lusan/data/common/DataTypeFactory.hpp
@@ -42,31 +42,6 @@ class DataTypeFactory
 {
 public:
 
-    static constexpr const char* const  TypeNameBool        { "bool"        };  //!< The boolean data type.
-    static constexpr const char* const  TypeNameChar        { "char"        };  //!< The 8-bit signed integer data type, or char
-    static constexpr const char* const  TypeNameUint8       { "uint8"       };  //!< The 8-bit unsigned integer data type, or byte
-    static constexpr const char* const  TypeNameInt16       { "int16"       };  //!< The 16-bit signed integer data type, or short
-    static constexpr const char* const  TypeNameUint16      { "uint16"      };  //!< The 16-bit unsigned integer data type, or word
-    static constexpr const char* const  TypeNameInt32       { "int32"       };  //!< The 32-bit signed integer data type, or int
-    static constexpr const char* const  TypeNameUint32      { "uint32"      };  //!< The 32-bit unsigned integer data type, or dword
-    static constexpr const char* const  TypeNameInt64       { "int64"       };  //!< The 64-bit signed integer data type, or long
-    static constexpr const char* const  TypeNameUint64      { "uint64"      };  //!< The 64-bit unsigned integer data type, or qword
-    static constexpr const char* const  TypeNameFloat       { "float"       };  //!< The single precision floating point data type
-    static constexpr const char* const  TypeNameDouble      { "double"      };  //!< The double precision floating point data type
-    static constexpr const char* const  TypeNameString      { "String"      };  //!< The string data type
-    static constexpr const char* const  TypeNameBinary      { "BinaryBuffer"};  //!< The binary (Byte Buffer) data type
-    static constexpr const char* const  TypeNameDateTime    { "DateTime"    };  //!< The date and time data type
-    static constexpr const char* const  TypeNameArray       { "Array"       };  //!< The array data type
-    static constexpr const char* const  TypeNameLinkedList  { "LinkedList"  };  //!< The linked list data type
-    static constexpr const char* const  TypeNameHashMap     { "HashMap"     };  //!< The hash map data type
-    static constexpr const char* const  TypeNameMap         { "Map"         };  //!< The map data type
-    static constexpr const char* const  TypeNamePair        { "Pair"        };  //!< The pair data type
-    static constexpr const char* const  TypeNameNewType     { "NewType"     };  //!< The new container type data type
-    static constexpr const char* const  TypeNameEnumerate   { "Enumerate"   };  //!< The custom enumeration data type
-    static constexpr const char* const  TypeNameStructure   { "Structure"   };  //!< The custom structure data type
-    static constexpr const char* const  TypeNameImported    { "Imported"    };  //!< The custom imported data type
-    static constexpr const char* const  TypeNameDefined     { "Defined"     };  //!< The custom defined data type
-
     /**
      * \brief   Converts the given data type to string value.
      * \param   dataType    The data type to convert to string.

--- a/sources/lusan/data/si/SIDataTypeData.cpp
+++ b/sources/lusan/data/si/SIDataTypeData.cpp
@@ -21,7 +21,7 @@
 #include "lusan/common/XmlSI.hpp"
 #include "lusan/data/common/DataTypeBasic.hpp"
 #include "lusan/data/common/DataTypeCustom.hpp"
-#include "lusan/data/common/DataTypeDefined.hpp"
+#include "lusan/data/common/DataTypeContainer.hpp"
 #include "lusan/data/common/DataTypeEnum.hpp"
 #include "lusan/data/common/DataTypeFactory.hpp"
 #include "lusan/data/common/DataTypeImported.hpp"
@@ -244,7 +244,7 @@ void SIDataTypeData::setCustomDataTypes(QList<DataTypeCustom*>&& entries)
     }
 }
 
-void SIDataTypeData::getDataType(QList<DataTypeBase*>& out_dataTypes, const QList<DataTypeBase*>& excludes /*= QList<DataTypeCustom *>*/, bool makeSorting /*= true*/) const
+void SIDataTypeData::getDataType(QList<DataTypeBase*>& out_dataTypes, const QList<DataTypeBase*>& excludes /*= QList<DataTypeCustom *>*/, bool makeSorting /*= false*/) const
 {
     out_dataTypes.clear();
     const QList<DataTypePrimitive*>& primitives = getPrimitiveDataTypes();
@@ -512,9 +512,9 @@ DataTypeEnum* SIDataTypeData::addEnum(const QString& name)
     return static_cast<DataTypeEnum*>(addCustomDataType(name, DataTypeBase::eCategory::Enumeration));
 }
 
-DataTypeDefined* SIDataTypeData::addDefined(const QString& name)
+DataTypeContainer* SIDataTypeData::addContainer(const QString& name)
 {
-    return static_cast<DataTypeDefined*>(addCustomDataType(name, DataTypeBase::eCategory::Container));
+    return static_cast<DataTypeContainer*>(addCustomDataType(name, DataTypeBase::eCategory::Container));
 }
 
 DataTypeImported* SIDataTypeData::addImported(const QString& name)

--- a/sources/lusan/data/si/SIDataTypeData.hpp
+++ b/sources/lusan/data/si/SIDataTypeData.hpp
@@ -36,7 +36,7 @@ class QXmlStreamWriter;
 class DataTypeCustom;
 class DataTypeBasicContainer;
 class DataTypeBasicObject;
-class DataTypeDefined;
+class DataTypeContainer;
 class DataTypeEnum;
 class DataTypeImported;
 class DataTypePrimitive;
@@ -319,7 +319,7 @@ public:
      * \param   name    The name of the primitive data type.
      * \return  The created Container custom data type object.
      **/
-    DataTypeDefined* addDefined(const QString& name);
+    DataTypeContainer* addContainer(const QString& name);
 
     /**
      * \brief   Adds an Imported custom data type to the list.

--- a/sources/lusan/res/datatype.xml
+++ b/sources/lusan/res/datatype.xml
@@ -45,39 +45,39 @@
             <Variant cpp="double"/>
             <Variant java="double"/>
         </DataType>
-        <DataType ID="12" Type="Basic" Name="String">
+        <DataType ID="12" Type="BasicObject" Name="String">
             <Variant cpp="String" import="areg/base/String.hpp" />
             <Variant java="String" import="java.lang.String" />
         </DataType>
-        <DataType ID="13" Type="Basic" Name="BinaryBuffer">
+        <DataType ID="13" Type="BasicObject" Name="BinaryBuffer">
             <Variant cpp="SharedBuffer" import="areg/base/SharedBuffer.hpp" />
             <Variant java="ByteBuffer" import="java.nio.ByteBuffer" />
         </DataType>
-        <DataType ID="14" Type="Basic" Name="DateTime">
+        <DataType ID="14" Type="BasicObject" Name="DateTime">
             <Variant cpp="DateTime" import="areg/base/DateTime.hpp" />
             <Variant java="Date" import="java.util.Date" />
         </DataType>
-        <DataType ID="15" Type="Container" Name="Array" HasKey="false" HasValue="true">
+        <DataType ID="15" Type="BasicContainer" Name="Array" HasKey="false" HasValue="true">
             <Variant cpp="TEArrayList" import="areg/base/TEArrayList.hpp" />
             <Variant java="ArrayList" import="java.util.ArrayList" />
         </DataType>
-        <DataType ID="16" Type="Container" Name="LinkedList" HasKey="false" HasValue="true">
+        <DataType ID="16" Type="BasicContainer" Name="LinkedList" HasKey="false" HasValue="true">
             <Variant cpp="TELinkedList" import="areg/base/TELinkedList.hpp" />
             <Variant java="LinkedList" import="java.util.LinkedList" />
         </DataType>
-        <DataType ID="17" Type="Container" Name="HashMap" HasKey="true" HasValue="true">
+        <DataType ID="17" Type="BasicContainer" Name="HashMap" HasKey="true" HasValue="true">
             <Variant cpp="TEHashMap" import="areg/base/TEHashMap.hpp" />
             <Variant java="HashMap" import="java.util.HashMap" />
         </DataType>
-        <DataType ID="18" Type="Container" Name="Map" HasKey="true" HasValue="true">
+        <DataType ID="18" Type="BasicContainer" Name="Map" HasKey="true" HasValue="true">
             <Variant cpp="TEMap" import="areg/base/TEMap.hpp" />
             <Variant java="Map" import="java.util.Map" />
         </DataType>
-        <DataType ID="19" Type="Container" Name="Pair" HasKey="true" HasValue="true">
+        <DataType ID="19" Type="BasicContainer" Name="Pair" HasKey="true" HasValue="true">
             <Variant cpp="TEPair" import="areg/base/TEPair.hpp" />
             <Variant java="Pair" import="javafx.util.Pair"/>
         </DataType>
-        <DataType ID="20" Type="Container" Name="New Type" HasKey="false" HasValue="true">
+        <DataType ID="20" Type="BasicContainer" Name="New Type" HasKey="false" HasValue="true">
             <Variant any="*" import="" />
         </DataType>
         <DataType ID="50" Type="Dummy" Name="Empty" HasKey="false" HasValue="false">

--- a/sources/lusan/view/common/DirSelectionDialog.cpp
+++ b/sources/lusan/view/common/DirSelectionDialog.cpp
@@ -78,7 +78,7 @@ void DirSelectionDialog::_initialize(const QString & curDir)
     mTreeViewDirs->sortByColumn(0, Qt::AscendingOrder);
     for (int i = 1; i < mModel->columnCount(); i++)
     {
-        // hide not required colums
+        // hide not required columns
         mTreeViewDirs->setColumnHidden(i, true);
     }
     

--- a/sources/lusan/view/si/SIDataType.cpp
+++ b/sources/lusan/view/si/SIDataType.cpp
@@ -22,7 +22,7 @@
 #include "ui/ui_SIDataType.h"
 
 #include "lusan/data/common/DataTypeBasic.hpp"
-#include "lusan/data/common/DataTypeDefined.hpp"
+#include "lusan/data/common/DataTypeContainer.hpp"
 #include "lusan/data/common/DataTypeEnum.hpp"
 #include "lusan/data/common/DataTypeFactory.hpp"
 #include "lusan/data/common/DataTypeImported.hpp"
@@ -168,7 +168,7 @@ void SIDataType::onCurCellChanged(QTreeWidgetItem *current, QTreeWidgetItem *pre
             break;
 
         case DataTypeBase::eCategory::Container:
-            selectedContainer(static_cast<DataTypeDefined*>(dataType));
+            selectedContainer(static_cast<DataTypeContainer*>(dataType));
             break;
 
         default:
@@ -348,7 +348,7 @@ void SIDataType::updateData(void)
             break;
 
         case DataTypeBase::eCategory::Container:
-            item = createNodeContainer(static_cast<DataTypeDefined*>(entry));
+            item = createNodeContainer(static_cast<DataTypeContainer*>(entry));
             break;
 
         default:
@@ -437,8 +437,8 @@ void SIDataType::onConvertDataType(QTreeWidgetItem* current, DataTypeBase::eCate
 
         case DataTypeBase::eCategory::Container:
             dataType = mModel.convertDataType(dataType, DataTypeBase::eCategory::Container);
-            updateNodeContainer(current, static_cast<DataTypeDefined*>(dataType));
-            selectedContainer(static_cast<DataTypeDefined*>(dataType));
+            updateNodeContainer(current, static_cast<DataTypeContainer*>(dataType));
+            selectedContainer(static_cast<DataTypeContainer*>(dataType));
             break;
 
         default:
@@ -460,7 +460,7 @@ void SIDataType::onContainerObjectChanged(int index)
     DataTypeBasicContainer*  dataType = static_cast<DataTypeBasicContainer *>(container->itemData(index, Qt::ItemDataRole::UserRole).value<DataTypeBase*>());
     Q_ASSERT(dataType != nullptr);
     QTreeWidgetItem* current = mList->ctrlTableList()->currentItem();
-    DataTypeDefined* typeContainer = static_cast<DataTypeDefined*>(current->data(0, Qt::ItemDataRole::UserRole).value<DataTypeCustom *>());
+    DataTypeContainer* typeContainer = static_cast<DataTypeContainer*>(current->data(0, Qt::ItemDataRole::UserRole).value<DataTypeCustom *>());
     Q_ASSERT(typeContainer->getCategory() == DataTypeBase::eCategory::Container);
     typeContainer->setContainer(dataType->getName());
     mDetails->ctrlContainerKey()->setEnabled(dataType->hasKey());
@@ -477,7 +477,7 @@ void SIDataType::onContainerKeyChanged(int index)
     DataTypeBase*  dataType = key->itemData(index, Qt::ItemDataRole::UserRole).value<DataTypeBase*>();
     Q_ASSERT(dataType != nullptr);
     QTreeWidgetItem* current = mList->ctrlTableList()->currentItem();
-    DataTypeDefined* typeContainer = static_cast<DataTypeDefined*>(current->data(0, Qt::ItemDataRole::UserRole).value<DataTypeCustom *>());
+    DataTypeContainer* typeContainer = static_cast<DataTypeContainer*>(current->data(0, Qt::ItemDataRole::UserRole).value<DataTypeCustom *>());
     Q_ASSERT(typeContainer->getCategory() == DataTypeBase::eCategory::Container);
     typeContainer->setKey(dataType->getName());
 }
@@ -493,7 +493,7 @@ void SIDataType::onContainerValueChanged(int index)
     DataTypeBase*  dataType = value->itemData(index, Qt::ItemDataRole::UserRole).value<DataTypeBase*>();
     Q_ASSERT(dataType != nullptr);
     QTreeWidgetItem* current = mList->ctrlTableList()->currentItem();
-    DataTypeDefined* typeContainer = static_cast<DataTypeDefined*>(current->data(0, Qt::ItemDataRole::UserRole).value<DataTypeCustom *>());
+    DataTypeContainer* typeContainer = static_cast<DataTypeContainer*>(current->data(0, Qt::ItemDataRole::UserRole).value<DataTypeCustom *>());
     Q_ASSERT(typeContainer->getCategory() == DataTypeBase::eCategory::Container);
     typeContainer->setKey(dataType->getName());
 }
@@ -712,7 +712,7 @@ void SIDataType::selectedImport(DataTypeImported* dataType)
     mList->ctrlToolMoveDown()->setEnabled((index >= 0) && (index < (mModel.getDataTypeCount() - 1)));
 }
 
-void SIDataType::selectedContainer(DataTypeDefined* dataType)
+void SIDataType::selectedContainer(DataTypeContainer* dataType)
 {
     activateFields(false);
     showEnumDetails(false);
@@ -844,7 +844,7 @@ QTreeWidgetItem* SIDataType::createNodeImported(DataTypeImported* dataType) cons
     return item;
 }
 
-QTreeWidgetItem* SIDataType::createNodeContainer(DataTypeDefined* dataType) const
+QTreeWidgetItem* SIDataType::createNodeContainer(DataTypeContainer* dataType) const
 {
     QTreeWidgetItem* item = new QTreeWidgetItem();
     updateNodeContainer(item, dataType);
@@ -904,7 +904,7 @@ void SIDataType::updateNodeImported(QTreeWidgetItem* node, DataTypeImported* dat
     node->setText(1, QString());
 }
 
-void SIDataType::updateNodeContainer(QTreeWidgetItem* node, DataTypeDefined* dataType) const
+void SIDataType::updateNodeContainer(QTreeWidgetItem* node, DataTypeContainer* dataType) const
 {
     node->setIcon(0, QIcon::fromTheme(QIcon::ThemeIcon::WeatherStorm));
     node->setData(0, Qt::ItemDataRole::UserRole, QVariant::fromValue(static_cast<DataTypeCustom *>(dataType)));

--- a/sources/lusan/view/si/SIDataType.hpp
+++ b/sources/lusan/view/si/SIDataType.hpp
@@ -24,7 +24,7 @@
 class DataTypeBasicContainer;
 class DataTypeCustom;
 class DataTypeContainer;
-class DataTypeDefined;
+class DataTypeContainer;
 class DataTypeEnum;
 class DataTypeImported;
 class DataTypePrimitive;
@@ -167,7 +167,7 @@ private:
 
     void selectedImport(DataTypeImported* dataType);
 
-    void selectedContainer(DataTypeDefined* dataType);
+    void selectedContainer(DataTypeContainer* dataType);
 
     void selectedStructField(const FieldEntry& field, DataTypeStructure* parent);
 
@@ -179,7 +179,7 @@ private:
 
     QTreeWidgetItem* createNodeImported(DataTypeImported* dataType) const;
     
-    QTreeWidgetItem* createNodeContainer(DataTypeDefined* dataType) const;
+    QTreeWidgetItem* createNodeContainer(DataTypeContainer* dataType) const;
 
     void updateNodeStructure(QTreeWidgetItem* node, DataTypeStructure* dataType) const;
 
@@ -187,7 +187,7 @@ private:
 
     void updateNodeImported(QTreeWidgetItem* node, DataTypeImported* dataType) const;
 
-    void updateNodeContainer(QTreeWidgetItem* node, DataTypeDefined* dataType) const;
+    void updateNodeContainer(QTreeWidgetItem* node, DataTypeContainer* dataType) const;
 
     void updateChildNodeStruct(QTreeWidgetItem* child, DataTypeStructure* dataType, const FieldEntry& field) const;
 

--- a/sources/lusan/view/si/ui/SIDataTypeDetails.ui
+++ b/sources/lusan/view/si/ui/SIDataTypeDetails.ui
@@ -187,7 +187,7 @@
            <item row="0" column="0">
             <widget class="QLabel" name="labelContainerObject">
              <property name="text">
-              <string>Object:</string>
+              <string>Base:</string>
              </property>
             </widget>
            </item>

--- a/sources/lusan/view/si/ui/SIDataTypeDetails.ui
+++ b/sources/lusan/view/si/ui/SIDataTypeDetails.ui
@@ -96,7 +96,7 @@
            <item row="0" column="1">
             <widget class="QRadioButton" name="radioTypeEnum">
              <property name="text">
-              <string>Enumerate</string>
+              <string>Enumeration</string>
              </property>
             </widget>
            </item>
@@ -255,7 +255,7 @@
         <item row="2" column="0">
          <widget class="QLabel" name="labelEnum">
           <property name="text">
-           <string>Enumerate:</string>
+           <string>Enumeration:</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Renamed `DataTypeDefined` to `DataTypeContainer` and fixed the order of primitive integer elements