### PR TITLE
Fixed issue when deleting response

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 set(PROJECT_NAME    lusan)
 set(PROJECT_VERSION_MAJOR 1)

--- a/sources/lusan/data/si/SIMethodRequest.cpp
+++ b/sources/lusan/data/si/SIMethodRequest.cpp
@@ -96,6 +96,11 @@ const SIMethodResponse* SIMethodRequest::getConectedResponse(void) const
     return mResponse.getType();
 }
 
+bool SIMethodRequest::hasValidResponse(void) const
+{
+    return mResponse.isValid();
+}
+
 void SIMethodRequest::clearResponse(void)
 {
     mResponse.invalidate();

--- a/sources/lusan/data/si/SIMethodRequest.hpp
+++ b/sources/lusan/data/si/SIMethodRequest.hpp
@@ -123,8 +123,16 @@ public:
 //////////////////////////////////////////////////////////////////////////
 public:
 
+    /**
+     * \brief   Normalizes the connected responses, searches the entry in the list.
+     * \param   listResponses   The list of responses to search the connected response.
+     **/
     void normalize(const QList<SIMethodResponse*>& listResponses);
 
+    /**
+     * \brief   Connects the response to the request.
+     * \param   respMethod  The response to connect.
+     **/
     void connectResponse(SIMethodResponse* respMethod);
 
     /**
@@ -140,12 +148,20 @@ public:
     const SIMethodResponse* getConectedResponse(void) const;
 
     /**
+     * \brief   Returns true if the connected response is valid.
+     **/
+    bool hasValidResponse(void) const;
+
+    /**
      * \brief   Clears the connected response name.
      **/
     void clearResponse(void);
 
+//////////////////////////////////////////////////////////////////////////
+// Member variables.
+//////////////////////////////////////////////////////////////////////////
 private:
-    SIResponseLink mResponse;
+    SIResponseLink mResponse;   //!< The connected response object.
 };
 
 #endif // LUSAN_DATA_SI_SIMETHODREQUEST_HPP

--- a/sources/lusan/view/si/SIMethod.cpp
+++ b/sources/lusan/view/si/SIMethod.cpp
@@ -740,19 +740,29 @@ void SIMethod::showMethodDetails(SIMethodBase* method)
         {
         case SIMethodBase::eMethodType::MethodRequest:
             mDetails->ctrlConnectedResponse()->setEnabled(true);
-            mDetails->ctrlConnectedResponse()->setCurrentText(static_cast<SIMethodRequest *>(method)->getConectedResponseName());
             mDetails->ctrlRequest()->setChecked(true);
+            if (static_cast<SIMethodRequest *>(method)->hasValidResponse())
+            {
+                mDetails->ctrlConnectedResponse()->setCurrentText(static_cast<SIMethodRequest *>(method)->getConectedResponseName());
+            }
+            else
+            {
+                mDetails->ctrlConnectedResponse()->setCurrentText(QString());
+            }
             break;
+
         case SIMethodBase::eMethodType::MethodResponse:
             mDetails->ctrlConnectedResponse()->setEnabled(false);
             mDetails->ctrlConnectedResponse()->setCurrentText(QString());
             mDetails->ctrlResponse()->setChecked(true);
             break;
+
         case SIMethodBase::eMethodType::MethodBroadcast:
             mDetails->ctrlConnectedResponse()->setEnabled(false);
             mDetails->ctrlConnectedResponse()->setCurrentText(QString());
             mDetails->ctrlBroadcast()->setChecked(true);
             break;
+
         default:
             break;
         }


### PR DESCRIPTION
was not able to reproduce the original bug.
Instead, have noticed that when the response is deleted, the `Reply` combo-box shows wrong response name. This issue is fixed.