### PR TITLE
Unified validation

### DIFF
--- a/sources/lusan/common/NELusanCommon.cpp
+++ b/sources/lusan/common/NELusanCommon.cpp
@@ -9,7 +9,7 @@
  *  For detailed licensing terms, please refer to the LICENSE file included
  *  with this distribution or contact us at info[at]areg.tech.
  *
- *  \copyright   © 2023-2026 Aregtech (Artak Avetyan).
+ *  \copyright   (c) 2023-2026 Aregtech (Artak Avetyan).
  *  \file        lusan/common/NELusanCommon.cpp
  *  \ingroup     Lusan - GUI Tool for Areg SDK
  *  \author      Artak Avetyan
@@ -227,7 +227,9 @@ const QString& NELusanCommon::identifierPattern()
 bool NELusanCommon::isValidIdentifier(const QString& name)
 {
     static const QRegularExpression _re{ QStringLiteral("\\A[A-Za-z_][A-Za-z0-9_]*\\z") };
-    return (name.isEmpty() == false) && _re.match(name).hasMatch();
+    return (name.isEmpty() == false)
+        && (name.size() <= NELusanCommon::MAX_IDENTIFIER_LENGTH)
+        && _re.match(name).hasMatch();
 }
 
 QValidator* NELusanCommon::createIdentifierValidator(QObject* parent)

--- a/sources/lusan/common/NELusanCommon.hpp
+++ b/sources/lusan/common/NELusanCommon.hpp
@@ -11,7 +11,7 @@
  *  For detailed licensing terms, please refer to the LICENSE file included
  *  with this distribution or contact us at info[at]areg.tech.
  *
- *  \copyright   © 2023-2026 Aregtech (Artak Avetyan).
+ *  \copyright   (c) 2023-2026 Aregtech (Artak Avetyan).
  *  \file        lusan/common/NELusanCommon.hpp
  *  \ingroup     Lusan - GUI Tool for Areg SDK
  *  \author      Artak Avetyan
@@ -674,8 +674,15 @@ namespace NELusanCommon
     const QString& identifierPattern();
 
     /**
-     * \brief   Returns true if the given text is a valid, complete C++ identifier.
-     *          Empty text is not valid. Shared by SI and FSM name-commit logic.
+     * \brief   The longest name any editor field accepts. The generated code carries the name
+     *          as written, so a name no compiler would take is refused where it is typed.
+     **/
+    constexpr int MAX_IDENTIFIER_LENGTH { 0xFF };
+
+    /**
+     * \brief   Returns true if the given text is a valid, complete C++ identifier of at most
+     *          \a MAX_IDENTIFIER_LENGTH characters. Empty text is not valid. This is the one
+     *          answer every document editor and every validation engine asks.
      **/
     bool isValidIdentifier(const QString& name);
 

--- a/sources/lusan/data/sm/StateMachineData.cpp
+++ b/sources/lusan/data/sm/StateMachineData.cpp
@@ -970,8 +970,7 @@ const QString& StateMachineData::identifierPattern()
 
 bool StateMachineData::isValidIdentifier(const QString& name)
 {
-    static const QRegularExpression _identifier{ StateMachineData::identifierPattern() };
-    return (name.size() <= StateMachineData::MAX_IDENTIFIER_LENGTH) && _identifier.match(name).hasMatch();
+    return NELusanCommon::isValidIdentifier(name);
 }
 
 int StateMachineData::getStateCount() const

--- a/sources/lusan/data/sm/StateMachineData.hpp
+++ b/sources/lusan/data/sm/StateMachineData.hpp
@@ -23,6 +23,7 @@
  * Includes
  ************************************************************************/
 #include "lusan/common/ElementBase.hpp"
+#include "lusan/common/NELusanCommon.hpp"
 #include "lusan/common/VersionNumber.hpp"
 
 #include "lusan/data/sm/SMOverviewData.hpp"
@@ -59,7 +60,8 @@ class StateMachineData  : protected QObject
 // Internal types and constants
 //////////////////////////////////////////////////////////////////////////
 public:
-    static constexpr int MAX_IDENTIFIER_LENGTH { 0xFF };
+    //!< The name length every editor field caps at, one value for every document kind.
+    static constexpr int MAX_IDENTIFIER_LENGTH { NELusanCommon::MAX_IDENTIFIER_LENGTH };
 
     /**
      * \enum    eStimulusType

--- a/sources/lusan/model/common/CMakeLists.txt
+++ b/sources/lusan/model/common/CMakeLists.txt
@@ -6,6 +6,7 @@
     ${LUSAN}/model/common/DocCommand.cpp
     ${LUSAN}/model/common/DocValidationController.cpp
     ${LUSAN}/model/common/DocModelNotifier.cpp
+    ${LUSAN}/model/common/DocRuleChecks.cpp
     ${LUSAN}/model/common/DocUnknownScan.cpp
     ${LUSAN}/model/common/IncludeModel.cpp
     ${LUSAN}/model/common/FileSystemEntry.cpp
@@ -26,6 +27,7 @@ list(APPEND LUSAN_HDR
     ${LUSAN}/model/common/DocValidationController.hpp
     ${LUSAN}/model/common/DocElementCommands.hpp
     ${LUSAN}/model/common/DocModelNotifier.hpp
+    ${LUSAN}/model/common/DocRuleChecks.hpp
     ${LUSAN}/model/common/DocUndoStack.hpp
     ${LUSAN}/model/common/DocUnknownScan.hpp
     ${LUSAN}/model/common/FileSystemEntry.hpp

--- a/sources/lusan/model/common/DocRuleChecks.cpp
+++ b/sources/lusan/model/common/DocRuleChecks.cpp
@@ -1,0 +1,255 @@
+/************************************************************************
+ *  This file is part of the Lusan project, an official component of the Areg SDK.
+ *  Lusan is a graphical user interface (GUI) tool designed to support the development,
+ *  debugging, and testing of applications built with the Areg Framework.
+ *
+ *  Lusan is available as free and open-source software under the Apache version 2.0 License,
+ *  providing essential features for developers.
+ *
+ *  For detailed licensing terms, please refer to the LICENSE file included
+ *  with this distribution or contact us at info[at]areg.tech.
+ *
+ *  \copyright   (c) 2023-2026 Aregtech (Artak Avetyan).
+ *  \file        lusan/model/common/DocRuleChecks.cpp
+ *  \ingroup     Lusan - GUI Tool for Areg SDK
+ *  \author      Artak Avetyan
+ *  \brief       Lusan application, the validation rules every document kind shares.
+ *
+ ************************************************************************/
+
+#include "lusan/model/common/DocRuleChecks.hpp"
+
+#include "lusan/common/NELusanCommon.hpp"
+#include "lusan/data/common/DataTypeCustom.hpp"
+#include "lusan/data/common/DataTypeDataSection.hpp"
+#include "lusan/data/common/DataTypeEnum.hpp"
+#include "lusan/data/common/DataTypeFactory.hpp"
+#include "lusan/model/common/LiteralValidator.hpp"
+
+#include <QRegularExpression>
+#include <QStringList>
+
+namespace
+{
+    //!< The separators of a templated declared type, such as `NEMap<String, Record>`.
+    const QRegularExpression& typeFragmentSeparator(void)
+    {
+        static const QRegularExpression _separator{ QStringLiteral("[<>,]") };
+        return _separator;
+    }
+}
+
+DocRuleChecks::DocRuleChecks(QList<DocIssue>& issues, const DataTypeDataSection& types, const RuleIds& rules)
+    : mIssues   (issues)
+    , mTypes    (types)
+    , mRules    (rules)
+{
+}
+
+bool DocRuleChecks::isIdentifier(const QString& name)
+{
+    return NELusanCommon::isValidIdentifier(name);
+}
+
+QString DocRuleChecks::explainShape(eShape shape)
+{
+    switch (shape)
+    {
+    case eShape::MissingName:
+        return tr("The generated code is named after this. It cannot be left empty.");
+
+    case eShape::InvalidIdentifier:
+        return tr("Names must be usable in generated code: a letter or underscore first, then letters, digits or underscores, and no more than %1 characters.")
+                    .arg(NELusanCommon::MAX_IDENTIFIER_LENGTH);
+
+    case eShape::DuplicateName:
+        return tr("Two declarations of the same kind reach one generated name this way, and the build then refuses whichever comes second. Names are unique per kind, so declarations of different kinds may share one.");
+
+    case eShape::UnresolvedType:
+        return tr("The declared type is not in the data type registry. Check the spelling, or declare the type on the Data Types page.");
+
+    case eShape::BadLiteral:
+        return tr("The value cannot be read as a value of the declared type.");
+
+    case eShape::Unreferenced:
+        return tr("Nothing in the document uses this declaration. Keep it if you are about to, or remove it.");
+
+    default:
+        return QString();
+    }
+}
+
+QString DocRuleChecks::literalReason(const DataTypeDataSection& types, const QString& typeName, const QString& literal)
+{
+    // An absent value is never a syntax fault: a value is optional, and absence is not a spelling.
+    if (literal.isEmpty() || typeName.isEmpty())
+        return QString();
+
+    DataTypeCustom* custom = types.findCustomDataType(typeName);
+    if (custom == nullptr)
+        return LiteralValidator::validate(typeName, literal);
+
+    switch (custom->getCategory())
+    {
+    case DataTypeBase::eCategory::Enumeration:
+        return (static_cast<DataTypeEnum*>(custom)->findElement(literal) != nullptr)
+                    ? QString()
+                    : tr("'%1' is not an enumerator of '%2'").arg(literal, typeName);
+
+    case DataTypeBase::eCategory::Structure:
+    case DataTypeBase::eCategory::Container:
+        return tr("'%1' has no literal form").arg(typeName);
+
+    default:
+        // Imported: the type is defined elsewhere and opaque here, so any literal is accepted.
+        return QString();
+    }
+}
+
+bool DocRuleChecks::typeResolves(const QString& fragment) const
+{
+    // Anything that is not a plain name is left alone: this is a registry lookup, not a parser.
+    if (isIdentifier(fragment) == false)
+        return true;
+    if (DataTypeFactory::fromString(fragment) != DataTypeBase::eCategory::Undefined)
+        return true;
+
+    return (mTypes.findCustomDataType(fragment) != nullptr);
+}
+
+QString DocRuleChecks::unresolvedFragment(const QString& typeName) const
+{
+    // Every name in a templated type has to exist too. Checking the whole string only would let
+    // `Array<Missing>` through.
+    const QStringList fragments = typeName.split(typeFragmentSeparator(), Qt::SkipEmptyParts);
+    for (const QString& fragment : fragments)
+    {
+        const QString name = fragment.trimmed();
+        if ((name.isEmpty() == false) && (typeResolves(name) == false))
+            return name;
+    }
+
+    return QString();
+}
+
+int DocRuleChecks::ruleId(int rule, DocIssue::eSeverity severity) const
+{
+    return (severity == DocIssue::eSeverity::Error) ? rule : (DocRuleChecks::ADVISORY_RULE_BASE + rule);
+}
+
+void DocRuleChecks::add(uint32_t id, eDocElementKind kind, DocIssue::eSeverity severity, int rule
+                       , const QString& message, const QString& detail)
+{
+    DocIssue issue;
+    issue.elementId = id;
+    issue.kind      = kind;
+    issue.severity  = severity;
+    issue.rule      = ruleId(rule, severity);
+    issue.message   = message;
+    issue.detail    = detail;
+    mIssues.append(issue);
+}
+
+void DocRuleChecks::checkIdentifier(uint32_t id, eDocElementKind kind, const QString& name, const QString& what)
+{
+    if (name.isEmpty())
+    {
+        add(id, kind, DocIssue::eSeverity::Error, mRules.missingName
+           , what.isEmpty() ? tr("A declaration has no name") : tr("%1 has no name").arg(what)
+           , explainShape(eShape::MissingName));
+    }
+    else if (isIdentifier(name) == false)
+    {
+        add(id, kind, DocIssue::eSeverity::Error, mRules.invalidIdentifier
+           , tr("'%1' is not a valid identifier").arg(name)
+           , explainShape(eShape::InvalidIdentifier));
+    }
+}
+
+QString DocRuleChecks::checkDeclaredType(uint32_t id, eDocElementKind kind, const QString& typeName
+                                        , const QString& what, bool required)
+{
+    if (typeName.isEmpty())
+    {
+        if (required)
+        {
+            add(id, kind, DocIssue::eSeverity::Error, mRules.unresolvedType
+               , what.isEmpty() ? tr("A declaration names no type") : tr("%1 declares no type").arg(what)
+               , explainShape(eShape::UnresolvedType));
+        }
+
+        return QString();
+    }
+
+    // Report the fragment, not the whole string: "Foo does not resolve" is actionable,
+    // "NEMap<String, Foo> does not resolve" is not.
+    const QString missing = unresolvedFragment(typeName);
+    if (missing.isEmpty() == false)
+    {
+        add(id, kind, DocIssue::eSeverity::Error, mRules.unresolvedType
+           , what.isEmpty() ? tr("Data type '%1' does not resolve").arg(missing)
+                            : tr("%1 declares type '%2', which does not exist").arg(what, missing)
+           , explainShape(eShape::UnresolvedType));
+    }
+
+    return missing;
+}
+
+void DocRuleChecks::checkLiteral(uint32_t id, eDocElementKind kind, const QString& typeName
+                                , const QString& literal, const QString& what)
+{
+    const QString reason = literalReason(mTypes, typeName, literal);
+    if (reason.isEmpty())
+        return;
+
+    add(id, kind, DocIssue::eSeverity::Error, mRules.badLiteral
+       , what.isEmpty() ? tr("Invalid %1 literal '%2': %3").arg(typeName, literal, reason)
+                        : tr("%1 has value '%2': %3").arg(what, literal, reason)
+       , explainShape(eShape::BadLiteral));
+}
+
+void DocRuleChecks::reportDuplicate(uint32_t id, eDocElementKind kind, const QString& subject
+                                   , DocIssue::eSeverity severity)
+{
+    add(id, kind, severity, mRules.duplicateName
+       , tr("%1 is declared more than once").arg(subject)
+       , explainShape(eShape::DuplicateName));
+}
+
+void DocRuleChecks::noteUnreferenced(uint32_t id, eDocElementKind kind, const QString& subject
+                                    , DocIssue::eSeverity severity, const QString& message)
+{
+    add(id, kind, severity, mRules.unreferenced
+       , message.isEmpty() ? tr("%1 is never referenced").arg(subject) : message
+       , explainShape(eShape::Unreferenced));
+}
+
+DocNameSet::DocNameSet(DocRuleChecks& checks, eDocElementKind kind, DocIssue::eSeverity severity)
+    : mChecks   (checks)
+    , mKind     (kind)
+    , mSeverity (severity)
+    , mTaken    ( )
+{
+}
+
+bool DocNameSet::claim(uint32_t id, const QString& name, const QString& subject)
+{
+    return claimKeyed(id, name, subject);
+}
+
+bool DocNameSet::claimKeyed(uint32_t id, const QString& key, const QString& subject)
+{
+    // An unnamed declaration is reported by the identifier rule; counting it here would report
+    // every unnamed one after the first as a duplicate of the first.
+    if (key.isEmpty())
+        return true;
+
+    if (mTaken.contains(key))
+    {
+        mChecks.reportDuplicate(id, mKind, subject, mSeverity);
+        return false;
+    }
+
+    mTaken.insert(key);
+    return true;
+}

--- a/sources/lusan/model/common/DocRuleChecks.hpp
+++ b/sources/lusan/model/common/DocRuleChecks.hpp
@@ -1,0 +1,255 @@
+#ifndef LUSAN_MODEL_COMMON_DOCRULECHECKS_HPP
+#define LUSAN_MODEL_COMMON_DOCRULECHECKS_HPP
+/************************************************************************
+ *  This file is part of the Lusan project, an official component of the Areg SDK.
+ *  Lusan is a graphical user interface (GUI) tool designed to support the development,
+ *  debugging, and testing of applications built with the Areg Framework.
+ *
+ *  Lusan is available as free and open-source software under the Apache version 2.0 License,
+ *  providing essential features for developers.
+ *
+ *  For detailed licensing terms, please refer to the LICENSE file included
+ *  with this distribution or contact us at info[at]areg.tech.
+ *
+ *  \copyright   (c) 2023-2026 Aregtech (Artak Avetyan).
+ *  \file        lusan/model/common/DocRuleChecks.hpp
+ *  \ingroup     Lusan - GUI Tool for Areg SDK
+ *  \author      Artak Avetyan
+ *  \brief       Lusan application, the validation rules every document kind shares.
+ *
+ ************************************************************************/
+
+/************************************************************************
+ * Includes
+ ************************************************************************/
+#include "lusan/model/common/DocIssue.hpp"
+
+#include <QCoreApplication>
+#include <QList>
+#include <QSet>
+#include <QString>
+#include <cstdint>
+
+/************************************************************************
+ * Dependencies
+ ************************************************************************/
+class DataTypeDataSection;
+
+/**
+ * \class   DocRuleChecks
+ * \brief   The checks that ask the same question of every document: is this name usable in
+ *          generated code, is it taken already, does this declared type exist, does this value
+ *          read as its type, and does anything use this declaration.
+ *
+ *          A document engine holds one of these, tells it which rule number it files each shape
+ *          under, and calls it instead of carrying its own copy. The number stays the engine's,
+ *          because the number is what an author reads and what the code generator files the same
+ *          fault under; the wording and the explanation come from here, so one defect never
+ *          reaches the results panel described two ways.
+ **/
+class DocRuleChecks
+{
+    Q_DECLARE_TR_FUNCTIONS(DocRuleChecks)
+
+//////////////////////////////////////////////////////////////////////////
+// Internal types and constants
+//////////////////////////////////////////////////////////////////////////
+public:
+    /**
+     * \brief   The rule number the host engine files each shared shape under. An engine that
+     *          reports two shapes under one number simply repeats it here.
+     **/
+    struct RuleIds
+    {
+        int missingName         { 0 };  //!< A declaration with no name at all.
+        int invalidIdentifier   { 0 };  //!< A name the generated code could not carry.
+        int duplicateName       { 0 };  //!< A name already taken in the same name space.
+        int unresolvedType      { 0 };  //!< A declared type nothing answers to.
+        int badLiteral          { 0 };  //!< A value that does not read as its declared type.
+        int unreferenced        { 0 };  //!< Advisory: nothing in the document uses the declaration.
+    };
+
+    /**
+     * \brief   The shared shapes, used to look up the one explanation each of them has.
+     **/
+    enum class eShape
+    {
+          MissingName
+        , InvalidIdentifier
+        , DuplicateName
+        , UnresolvedType
+        , BadLiteral
+        , Unreferenced
+    };
+
+    /**
+     * \brief   A warning or an advisory note `n` is reported with the rule id
+     *          (`ADVISORY_RULE_BASE + n`). A band, not a second severity of the same rule.
+     **/
+    static constexpr int ADVISORY_RULE_BASE { 100 };
+
+//////////////////////////////////////////////////////////////////////////
+// Constructors / Destructor
+//////////////////////////////////////////////////////////////////////////
+public:
+    /**
+     * \brief   Binds the checks to the finding list they append to and to the registry every
+     *          type question is answered against.
+     **/
+    DocRuleChecks(QList<DocIssue>& issues, const DataTypeDataSection& types, const RuleIds& rules);
+
+//////////////////////////////////////////////////////////////////////////
+// Operations, engine independent answers
+//////////////////////////////////////////////////////////////////////////
+public:
+    /**
+     * \brief   True when the text is a name the generated code can carry.
+     **/
+    static bool isIdentifier(const QString& name);
+
+    /**
+     * \brief   Why a finding of the given shape is a finding, and what resolves it.
+     **/
+    static QString explainShape(eShape shape);
+
+    /**
+     * \brief   Why the literal does not fit the declared type, or an empty string when it does.
+     *          An enumeration takes its own enumerators, a structure and a container take no
+     *          literal at all, an imported type is opaque and takes anything, and everything
+     *          else is parsed against the type's syntax.
+     **/
+    static QString literalReason(const DataTypeDataSection& types, const QString& typeName, const QString& literal);
+
+    /**
+     * \brief   True when the name fragment is a predefined type, a declared one, or not a plain
+     *          name at all -- this is a registry lookup, not a C++ parser.
+     **/
+    bool typeResolves(const QString& fragment) const;
+
+    /**
+     * \brief   The first name in a declared type that answers to nothing, or an empty string.
+     *          A templated type is checked fragment by fragment, so `Array<Missing>` reports
+     *          `Missing` rather than the whole string.
+     **/
+    QString unresolvedFragment(const QString& typeName) const;
+
+    /**
+     * \brief   The rule id a finding of this severity carries, advisory band applied.
+     **/
+    int ruleId(int rule, DocIssue::eSeverity severity) const;
+
+//////////////////////////////////////////////////////////////////////////
+// Operations, the shared rules
+//////////////////////////////////////////////////////////////////////////
+public:
+    /**
+     * \brief   Appends a finding, applying the advisory band to the rule number.
+     **/
+    void add(uint32_t id, eDocElementKind kind, DocIssue::eSeverity severity, int rule
+            , const QString& message, const QString& detail);
+
+    /**
+     * \brief   The name has to be there and has to be usable in generated code.
+     * \param   what    The subject of the message, such as `Attribute 'speed'`. Used when the
+     *                  name is missing, which is the case a name cannot describe itself.
+     **/
+    void checkIdentifier(uint32_t id, eDocElementKind kind, const QString& name, const QString& what);
+
+    /**
+     * \brief   The declared type has to exist, and every fragment of a templated one with it.
+     * \param   required    True when the declaration cannot be left without a type.
+     * \return  The fragment that answered to nothing, or an empty string.
+     **/
+    QString checkDeclaredType(uint32_t id, eDocElementKind kind, const QString& typeName
+                             , const QString& what, bool required);
+
+    /**
+     * \brief   The value has to read as a value of the declared type.
+     * \param   what    The subject of the message. Empty where the call site has none, and the
+     *                  message then names the type instead.
+     **/
+    void checkLiteral(uint32_t id, eDocElementKind kind, const QString& typeName
+                     , const QString& literal, const QString& what);
+
+    /**
+     * \brief   Files a name that is already taken.
+     * \param   subject The whole subject, such as `Attribute 'speed'`.
+     **/
+    void reportDuplicate(uint32_t id, eDocElementKind kind, const QString& subject
+                        , DocIssue::eSeverity severity = DocIssue::eSeverity::Error);
+
+    /**
+     * \brief   Files a declaration nothing in the document uses.
+     * \param   message An alternative wording, for a declaration that is used in one named way.
+     **/
+    void noteUnreferenced(uint32_t id, eDocElementKind kind, const QString& subject
+                         , DocIssue::eSeverity severity, const QString& message = QString());
+
+//////////////////////////////////////////////////////////////////////////
+// Attributes
+//////////////////////////////////////////////////////////////////////////
+private:
+    QList<DocIssue>&            mIssues;    //!< The run's findings.
+    const DataTypeDataSection&  mTypes;     //!< The document's data type registry.
+    RuleIds                     mRules;     //!< The numbers this engine files the shapes under.
+
+//////////////////////////////////////////////////////////////////////////
+// Forbidden calls
+//////////////////////////////////////////////////////////////////////////
+private:
+    DocRuleChecks(void) = delete;
+    DocRuleChecks(const DocRuleChecks& /*src*/) = delete;
+    DocRuleChecks& operator = (const DocRuleChecks& /*src*/) = delete;
+};
+
+/**
+ * \class   DocNameSet
+ * \brief   One name space of a document: the names already taken in it, and the finding filed
+ *          on the second declaration that claims one. A section has one of these; a section
+ *          whose names are unique per kind keys them by kind and still needs only one.
+ **/
+class DocNameSet
+{
+//////////////////////////////////////////////////////////////////////////
+// Constructors / Destructor
+//////////////////////////////////////////////////////////////////////////
+public:
+    DocNameSet(DocRuleChecks& checks, eDocElementKind kind
+              , DocIssue::eSeverity severity = DocIssue::eSeverity::Error);
+
+//////////////////////////////////////////////////////////////////////////
+// Operations
+//////////////////////////////////////////////////////////////////////////
+public:
+    /**
+     * \brief   Claims the name for the element. Files the duplicate rule and returns false when
+     *          the name was claimed before.
+     * \param   subject The whole subject of the message, such as `Attribute 'speed'`.
+     **/
+    bool claim(uint32_t id, const QString& name, const QString& subject);
+
+    /**
+     * \brief   The same, for a name space keyed by something the message does not show, such as
+     *          the kind a method was declared as.
+     **/
+    bool claimKeyed(uint32_t id, const QString& key, const QString& subject);
+
+//////////////////////////////////////////////////////////////////////////
+// Attributes
+//////////////////////////////////////////////////////////////////////////
+private:
+    DocRuleChecks&      mChecks;
+    eDocElementKind     mKind;
+    DocIssue::eSeverity mSeverity;
+    QSet<QString>       mTaken;
+
+//////////////////////////////////////////////////////////////////////////
+// Forbidden calls
+//////////////////////////////////////////////////////////////////////////
+private:
+    DocNameSet(void) = delete;
+    DocNameSet(const DocNameSet& /*src*/) = delete;
+    DocNameSet& operator = (const DocNameSet& /*src*/) = delete;
+};
+
+#endif  // LUSAN_MODEL_COMMON_DOCRULECHECKS_HPP

--- a/sources/lusan/model/common/LiteralValidator.hpp
+++ b/sources/lusan/model/common/LiteralValidator.hpp
@@ -1,5 +1,5 @@
-#ifndef LUSAN_MODEL_SM_SMLITERALVALIDATOR_HPP
-#define LUSAN_MODEL_SM_SMLITERALVALIDATOR_HPP
+#ifndef LUSAN_MODEL_COMMON_LITERALVALIDATOR_HPP
+#define LUSAN_MODEL_COMMON_LITERALVALIDATOR_HPP
 /************************************************************************
  *  This file is part of the Lusan project, an official component of the Areg SDK.
  *  Lusan is a graphical user interface (GUI) tool designed to support the development,
@@ -11,11 +11,11 @@
  *  For detailed licensing terms, please refer to the LICENSE file included
  *  with this distribution or contact us at info[at]areg.tech.
  *
- *  \copyright   © 2023-2026 Aregtech (Artak Avetyan).
+ *  \copyright   (c) 2023-2026 Aregtech (Artak Avetyan).
  *  \file        lusan/model/common/LiteralValidator.hpp
  *  \ingroup     Lusan - GUI Tool for Areg SDK
  *  \author      Artak Avetyan
- *  \brief       Lusan application, FSM literal value syntax validator
+ *  \brief       Lusan application, literal value syntax validator shared by every document
  *
  ************************************************************************/
 
@@ -25,7 +25,7 @@
  * \brief   Validates a literal against a primitive data type's syntax: bool,
  *          char, signed/unsigned integers (decimal or `0x` hexadecimal, range-checked per
  *          bit width), float/double, and String (unrestricted). Enumeration, structure,
- *          container and imported types have no literal syntax of their own — callers
+ *          container and imported types have no literal syntax of their own -- callers
  *          resolve an enumeration literal against the declared type's enumerators and
  *          disable literal entry entirely for structure/container/imported types.
  **/
@@ -37,7 +37,7 @@ public:
      * \param   typeName    One of the `.siml` primitive names (bool, char, int8..int64,
      *                      uint8..uint64, float, double, String). Any other name (a declared
      *                      enumeration/structure/container/imported type) always validates.
-     * \param   literal     The literal text to check. An empty literal always validates — a
+     * \param   literal     The literal text to check. An empty literal always validates -- a
      *                      default/value is optional, so absence is not a syntax error.
      * \return  An empty string if the literal is valid; otherwise a short, user-facing reason.
      **/
@@ -51,4 +51,4 @@ private:
     static QString validateFloatingPoint(const QString& literal);
 };
 
-#endif  // LUSAN_MODEL_SM_SMLITERALVALIDATOR_HPP
+#endif  // LUSAN_MODEL_COMMON_LITERALVALIDATOR_HPP

--- a/sources/lusan/model/si/SIValidator.cpp
+++ b/sources/lusan/model/si/SIValidator.cpp
@@ -19,13 +19,11 @@
 
 #include "lusan/model/si/SIValidator.hpp"
 
-#include "lusan/common/NELusanCommon.hpp"
 #include "lusan/data/common/AttributeEntry.hpp"
 #include "lusan/data/common/ConstantEntry.hpp"
 #include "lusan/data/common/DataTypeContainer.hpp"
 #include "lusan/data/common/DataTypeCustom.hpp"
 #include "lusan/data/common/DataTypeEnum.hpp"
-#include "lusan/data/common/DataTypeFactory.hpp"
 #include "lusan/data/common/DataTypeStructure.hpp"
 #include "lusan/data/common/EnumEntry.hpp"
 #include "lusan/data/common/FieldEntry.hpp"
@@ -33,10 +31,9 @@
 #include "lusan/data/common/MethodParameter.hpp"
 #include "lusan/data/si/ServiceInterfaceData.hpp"
 #include "lusan/data/common/MethodDataSection.hpp"
-#include "lusan/model/common/LiteralValidator.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
 
 #include <QCoreApplication>
-#include <QHash>
 #include <QRegularExpression>
 #include <QSet>
 #include <QStringList>
@@ -58,6 +55,22 @@ namespace
         return label.isEmpty() ? vtr("Method") : label;
     }
 
+    //!< The numbers this engine has always filed the shared shapes under.
+    const DocRuleChecks::RuleIds& siRules()
+    {
+        static const DocRuleChecks::RuleIds _rules
+        {
+              SIValidator::RULE_MISSING_NAME
+            , SIValidator::RULE_INVALID_IDENTIFIER
+            , SIValidator::RULE_DUPLICATE_NAME
+            , SIValidator::RULE_UNRESOLVED_TYPE
+            , SIValidator::RULE_BAD_LITERAL
+            , SIValidator::RULE_UNREFERENCED
+        };
+
+        return _rules;
+    }
+
     /**
      * \class   Ctx
      * \brief   One validation run: the document, the findings it produced, and the registry
@@ -69,6 +82,7 @@ namespace
         explicit Ctx(const ServiceInterfaceData& data)
             : mData     (data)
             , mIssues   ( )
+            , mChecks   (mIssues, data.getDataTypeData(), siRules())
             , mTypesUsed( )
             , mConstsUsed( )
         {
@@ -78,12 +92,6 @@ namespace
 
     private:
         void add(uint32_t id, eDocElementKind kind, eSeverity sev, int rule, const QString& message);
-
-        //!< True when the name is a primitive, a basic object/container or a declared custom type.
-        bool typeResolves(const QString& typeName) const;
-
-        //!< The first fragment of a declared type that resolves to nothing, or an empty string.
-        QString unresolvedFragment(const QString& typeName) const;
 
         void checkName(uint32_t id, eDocElementKind kind, const QString& name, const QString& what);
         void checkType(uint32_t id, eDocElementKind kind, const QString& typeName, const QString& what);
@@ -104,6 +112,7 @@ namespace
     private:
         const ServiceInterfaceData& mData;
         QList<DocIssue>             mIssues;
+        DocRuleChecks               mChecks;        //!< The rules every document kind shares.
         QSet<QString>               mTypesUsed;     //!< Type names something in the document declares with.
         QSet<QString>               mConstsUsed;    //!< Constant names something in the document reads.
         bool                        mUnresolvedSeen { false };  //!< A declared type answered to nothing here.
@@ -111,41 +120,7 @@ namespace
 
     void Ctx::add(uint32_t id, eDocElementKind kind, eSeverity sev, int rule, const QString& message)
     {
-        DocIssue issue;
-        issue.elementId = id;
-        issue.kind      = kind;
-        issue.severity  = sev;
-        issue.rule      = (sev == eSeverity::Error) ? rule : (SIValidator::ADVISORY_RULE_BASE + rule);
-        issue.message   = message;
-        issue.detail    = SIValidator::explainRule(issue.rule, sev);
-        mIssues.append(issue);
-    }
-
-    bool Ctx::typeResolves(const QString& typeName) const
-    {
-        if (DataTypeFactory::fromString(typeName) != DataTypeBase::eCategory::Undefined)
-            return true;
-
-        return (mData.getDataTypeData().findDataType(typeName) != nullptr);
-    }
-
-    QString Ctx::unresolvedFragment(const QString& typeName) const
-    {
-        // A declared type may be written as a template, and every name in it has to exist. Checking
-        // the whole string only would let `Array<Missing>` through.
-        const QStringList fragments = typeName.split(QRegularExpression(QStringLiteral("[<>,]")), Qt::SkipEmptyParts);
-        for (const QString& fragment : fragments)
-        {
-            const QString name = fragment.trimmed();
-            // Anything that is not a plain name is left alone: this is a registry lookup, not a
-            // C++ parser.
-            if (name.isEmpty() || (NELusanCommon::isValidIdentifier(name) == false))
-                continue;
-            if (typeResolves(name) == false)
-                return name;
-        }
-
-        return QString();
+        mChecks.add(id, kind, sev, rule, message, SIValidator::explainRule(mChecks.ruleId(rule, sev), sev));
     }
 
     void Ctx::noteType(const QString& typeName)
@@ -163,50 +138,27 @@ namespace
 
     void Ctx::checkName(uint32_t id, eDocElementKind kind, const QString& name, const QString& what)
     {
-        if (name.isEmpty())
-        {
-            add(id, kind, eSeverity::Error, SIValidator::RULE_MISSING_NAME, vtr("%1 has no name").arg(what));
-        }
-        else if (NELusanCommon::isValidIdentifier(name) == false)
-        {
-            add(id, kind, eSeverity::Error, SIValidator::RULE_INVALID_IDENTIFIER, vtr("'%1' is not a valid identifier").arg(name));
-        }
+        mChecks.checkIdentifier(id, kind, name, what);
     }
 
     void Ctx::checkType(uint32_t id, eDocElementKind kind, const QString& typeName, const QString& what)
     {
-        if (typeName.isEmpty())
-        {
-            add(id, kind, eSeverity::Error, SIValidator::RULE_UNRESOLVED_TYPE, vtr("%1 declares no type").arg(what));
-            return;
-        }
-
         noteType(typeName);
-        const QString missing = unresolvedFragment(typeName);
-        if (missing.isEmpty() == false)
-        {
-            mUnresolvedSeen = true;
-            add(id, kind, eSeverity::Error, SIValidator::RULE_UNRESOLVED_TYPE, vtr("%1 declares type '%2', which does not exist").arg(what, missing));
-        }
+        const QString missing = mChecks.checkDeclaredType(id, kind, typeName, what, true);
+        // A name this document does not answer to may be one the imported data type document
+        // brings in, which is what keeps the unused-import advisory silent.
+        mUnresolvedSeen = mUnresolvedSeen || (missing.isEmpty() == false);
     }
 
     void Ctx::checkLiteral(uint32_t id, eDocElementKind kind, const QString& typeName, const QString& literal, const QString& what)
     {
-        // A declared type carries its own literal form, which this check does not read.
-        if (literal.isEmpty() || (mData.getDataTypeData().findCustomDataType(typeName) != nullptr))
-            return;
-
-        const QString reason = LiteralValidator::validate(typeName, literal);
-        if (reason.isEmpty() == false)
-        {
-            add(id, kind, eSeverity::Error, SIValidator::RULE_BAD_LITERAL, vtr("%1 has value '%2': %3").arg(what, literal, reason));
-        }
+        mChecks.checkLiteral(id, kind, typeName, literal, what);
     }
 
     void Ctx::checkParameters(const MethodEntry& method)
     {
         const QString kindWord = methodKindWord(method);
-        QSet<QString> names;
+        DocNameSet names(mChecks, eDocElementKind::Method);
         bool defaulted = false;
         for (const MethodParameter& param : method.getElements())
         {
@@ -214,14 +166,7 @@ namespace
             checkName(method.getId(), eDocElementKind::Method, param.getName(), where);
             checkType(method.getId(), eDocElementKind::Method, param.getType(), where);
             checkLiteral(method.getId(), eDocElementKind::Method, param.getType(), param.getValue(), where);
-
-            if (names.contains(param.getName()))
-            {
-                add(method.getId(), eDocElementKind::Method, eSeverity::Error, SIValidator::RULE_DUPLICATE_NAME
-                   , vtr("%1 '%2' declares parameter '%3' twice").arg(kindWord, method.getName(), param.getName()));
-            }
-
-            names.insert(param.getName());
+            names.claim(method.getId(), param.getName(), where);
 
             // A caller may only leave out the trailing parameters, so once one carries a default
             // every parameter after it has to carry one too.
@@ -259,7 +204,7 @@ namespace
 
     void Ctx::checkDataTypes()
     {
-        QSet<QString> names;
+        DocNameSet names(mChecks, eDocElementKind::DataType);
         for (DataTypeCustom* dataType : mData.getDataTypeData().getCustomDataTypes())
         {
             if (dataType == nullptr)
@@ -268,31 +213,19 @@ namespace
             const uint32_t id = dataType->getId();
             const QString name = dataType->getName();
             checkName(id, eDocElementKind::DataType, name, vtr("The data type"));
-            if (names.contains(name))
-            {
-                add(id, eDocElementKind::DataType, eSeverity::Error, SIValidator::RULE_DUPLICATE_NAME
-                   , vtr("Data type '%1' is declared more than once").arg(name));
-            }
-
-            names.insert(name);
+            names.claim(id, name, vtr("Data type '%1'").arg(name));
 
             if (dataType->getCategory() == DataTypeBase::eCategory::Structure)
             {
                 DataTypeStructure* structType = static_cast<DataTypeStructure*>(dataType);
-                QSet<QString> fields;
+                DocNameSet fields(mChecks, eDocElementKind::DataType);
                 for (const FieldEntry& field : structType->getElements())
                 {
                     const QString where = vtr("Field '%1' of structure '%2'").arg(field.getName(), name);
                     checkName(id, eDocElementKind::DataType, field.getName(), where);
                     checkType(id, eDocElementKind::DataType, field.getType(), where);
                     checkLiteral(id, eDocElementKind::DataType, field.getType(), field.getValue(), where);
-                    if (fields.contains(field.getName()))
-                    {
-                        add(id, eDocElementKind::DataType, eSeverity::Error, SIValidator::RULE_DUPLICATE_NAME
-                           , vtr("Structure '%1' declares field '%2' twice").arg(name, field.getName()));
-                    }
-
-                    fields.insert(field.getName());
+                    fields.claim(id, field.getName(), where);
                 }
 
                 if (structType->getElementCount() == 0)
@@ -304,17 +237,12 @@ namespace
             else if (dataType->getCategory() == DataTypeBase::eCategory::Enumeration)
             {
                 DataTypeEnum* enumType = static_cast<DataTypeEnum*>(dataType);
-                QSet<QString> fields;
+                DocNameSet fields(mChecks, eDocElementKind::DataType);
                 for (const EnumEntry& field : enumType->getElements())
                 {
-                    checkName(id, eDocElementKind::DataType, field.getName(), vtr("Value '%1' of enumeration '%2'").arg(field.getName(), name));
-                    if (fields.contains(field.getName()))
-                    {
-                        add(id, eDocElementKind::DataType, eSeverity::Error, SIValidator::RULE_DUPLICATE_NAME
-                           , vtr("Enumeration '%1' declares value '%2' twice").arg(name, field.getName()));
-                    }
-
-                    fields.insert(field.getName());
+                    const QString where = vtr("Value '%1' of enumeration '%2'").arg(field.getName(), name);
+                    checkName(id, eDocElementKind::DataType, field.getName(), where);
+                    fields.claim(id, field.getName(), where);
                 }
 
                 if (enumType->getElementCount() == 0)
@@ -343,20 +271,15 @@ namespace
 
     void Ctx::checkAttributes()
     {
-        QSet<QString> names;
+        DocNameSet names(mChecks, eDocElementKind::Attribute);
         for (const AttributeEntry& attribute : mData.getAttributeData().getElements())
         {
             const uint32_t id = attribute.getId();
             const QString name = attribute.getName();
+            const QString where = vtr("Attribute '%1'").arg(name);
             checkName(id, eDocElementKind::Attribute, name, vtr("The attribute"));
-            checkType(id, eDocElementKind::Attribute, attribute.getType(), vtr("Attribute '%1'").arg(name));
-            if (names.contains(name))
-            {
-                add(id, eDocElementKind::Attribute, eSeverity::Error, SIValidator::RULE_DUPLICATE_NAME
-                   , vtr("Attribute '%1' is declared more than once").arg(name));
-            }
-
-            names.insert(name);
+            checkType(id, eDocElementKind::Attribute, attribute.getType(), where);
+            names.claim(id, name, where);
         }
     }
 
@@ -364,7 +287,7 @@ namespace
     {
         // Names are unique per method kind: a request, a response and a broadcast may share one
         // name, but two requests may not.
-        QHash<int, QSet<QString> > names;
+        DocNameSet names(mChecks, eDocElementKind::Method);
         for (MethodEntry* method : mData.getMethodData().getElements())
         {
             if (method == nullptr)
@@ -375,15 +298,8 @@ namespace
             const QString kindWord = methodKindWord(*method);
             checkName(id, eDocElementKind::Method, name, vtr("The %1").arg(kindWord.toLower()));
             checkParameters(*method);
-
-            QSet<QString>& taken = names[static_cast<int>(method->getKind())];
-            if (taken.contains(name))
-            {
-                add(id, eDocElementKind::Method, eSeverity::Error, SIValidator::RULE_DUPLICATE_NAME
-                   , vtr("%1 '%2' is declared more than once").arg(kindWord, name));
-            }
-
-            taken.insert(name);
+            names.claimKeyed(id, QString::number(method->getKind()) + QLatin1Char(':') + name
+                            , vtr("%1 '%2'").arg(kindWord, name));
         }
 
         // A request either answers with a declared response or answers with nothing at all; a name
@@ -424,21 +340,16 @@ namespace
 
     void Ctx::checkConstants()
     {
-        QSet<QString> names;
+        DocNameSet names(mChecks, eDocElementKind::Constant);
         for (const ConstantEntry& constant : mData.getConstantData().getElements())
         {
             const uint32_t id = constant.getId();
             const QString name = constant.getName();
+            const QString where = vtr("Constant '%1'").arg(name);
             checkName(id, eDocElementKind::Constant, name, vtr("The constant"));
-            checkType(id, eDocElementKind::Constant, constant.getType(), vtr("Constant '%1'").arg(name));
-            checkLiteral(id, eDocElementKind::Constant, constant.getType(), constant.getValue(), vtr("Constant '%1'").arg(name));
-            if (names.contains(name))
-            {
-                add(id, eDocElementKind::Constant, eSeverity::Error, SIValidator::RULE_DUPLICATE_NAME
-                   , vtr("Constant '%1' is declared more than once").arg(name));
-            }
-
-            names.insert(name);
+            checkType(id, eDocElementKind::Constant, constant.getType(), where);
+            checkLiteral(id, eDocElementKind::Constant, constant.getType(), constant.getValue(), where);
+            names.claim(id, name, where);
         }
     }
 
@@ -456,8 +367,10 @@ namespace
             }
             else if (locations.contains(location))
             {
-                add(include.getId(), eDocElementKind::Include, eSeverity::Warning, SIValidator::RULE_DUPLICATE_NAME
-                   , vtr("'%1' is included more than once").arg(location));
+                // An include is keyed by its location, so the duplicate rule reads the path here.
+                mChecks.add(include.getId(), eDocElementKind::Include, eSeverity::Warning, SIValidator::RULE_DUPLICATE_NAME
+                           , vtr("'%1' is included more than once").arg(location)
+                           , DocRuleChecks::explainShape(DocRuleChecks::eShape::DuplicateName));
             }
 
             // A service interface includes no other service interface, so it has no document
@@ -491,8 +404,8 @@ namespace
         {
             if ((dataType != nullptr) && (mTypesUsed.contains(dataType->getName()) == false))
             {
-                add(dataType->getId(), eDocElementKind::DataType, eSeverity::Warning, SIValidator::RULE_UNREFERENCED
-                   , vtr("Data type '%1' is never referenced").arg(dataType->getName()));
+                mChecks.noteUnreferenced(dataType->getId(), eDocElementKind::DataType
+                                        , vtr("Data type '%1'").arg(dataType->getName()), eSeverity::Warning);
             }
         }
 
@@ -500,8 +413,8 @@ namespace
         {
             if (mConstsUsed.contains(constant.getName()) == false)
             {
-                add(constant.getId(), eDocElementKind::Constant, eSeverity::Info, SIValidator::RULE_UNREFERENCED
-                   , vtr("Constant '%1' is never referenced").arg(constant.getName()));
+                mChecks.noteUnreferenced(constant.getId(), eDocElementKind::Constant
+                                        , vtr("Constant '%1'").arg(constant.getName()), eSeverity::Info);
             }
         }
     }
@@ -587,7 +500,7 @@ QString SIValidator::explainRule(int rule, DocIssue::eSeverity severity)
         case SIValidator::RULE_EMPTY_TYPE:
             return QCoreApplication::translate("SIValidator", "The type generates an empty declaration. Give it its members, or remove it.");
         case SIValidator::RULE_UNREFERENCED:
-            return QCoreApplication::translate("SIValidator", "Nothing in the interface uses this declaration. Keep it if you are about to, or remove it.");
+            return DocRuleChecks::explainShape(DocRuleChecks::eShape::Unreferenced);
         case SIValidator::RULE_UNBOUND_RESPONSE:
             return QCoreApplication::translate("SIValidator", "A response is what a request answers with. Connect it to the request it belongs to, or remove it.");
         case SIValidator::RULE_EMPTY_INTERFACE:
@@ -602,15 +515,15 @@ QString SIValidator::explainRule(int rule, DocIssue::eSeverity severity)
     switch (rule)
     {
     case SIValidator::RULE_MISSING_NAME:
-        return QCoreApplication::translate("SIValidator", "The generated code is named after this. It cannot be left empty.");
+        return DocRuleChecks::explainShape(DocRuleChecks::eShape::MissingName);
     case SIValidator::RULE_INVALID_IDENTIFIER:
-        return QCoreApplication::translate("SIValidator", "Names must be usable in generated code: a letter or underscore first, then letters, digits or underscores.");
+        return DocRuleChecks::explainShape(DocRuleChecks::eShape::InvalidIdentifier);
     case SIValidator::RULE_DUPLICATE_NAME:
-        return QCoreApplication::translate("SIValidator", "Two declarations reach one generated name this way, and the build then refuses whichever comes second.");
+        return DocRuleChecks::explainShape(DocRuleChecks::eShape::DuplicateName);
     case SIValidator::RULE_UNRESOLVED_TYPE:
-        return QCoreApplication::translate("SIValidator", "The declared type is not in the data type registry. Check the spelling, or declare the type on the Data Types page.");
+        return DocRuleChecks::explainShape(DocRuleChecks::eShape::UnresolvedType);
     case SIValidator::RULE_BAD_LITERAL:
-        return QCoreApplication::translate("SIValidator", "The value cannot be read as a value of the declared type.");
+        return DocRuleChecks::explainShape(DocRuleChecks::eShape::BadLiteral);
     case SIValidator::RULE_RESPONSE_LINK:
         return QCoreApplication::translate("SIValidator", "A caller waits for the named response. Declare it, or clear the connection so the request answers with nothing.");
     case SIValidator::RULE_DEFAULT_ORDER:

--- a/sources/lusan/model/si/SIValidator.hpp
+++ b/sources/lusan/model/si/SIValidator.hpp
@@ -23,6 +23,7 @@
  * Includes
  ************************************************************************/
 #include "lusan/model/common/DocIssue.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
 
 #include <QList>
 #include <QString>
@@ -56,7 +57,7 @@ public:
      *          A band, not a second severity of the same rule: the id the author reads is the
      *          rule identity, so `n` and `ADVISORY_RULE_BASE + n` are two unrelated rules.
      **/
-    static constexpr int ADVISORY_RULE_BASE { 100 };
+    static constexpr int ADVISORY_RULE_BASE { DocRuleChecks::ADVISORY_RULE_BASE };
 
     static constexpr int RULE_MISSING_NAME          { 1 };  //!< The interface, or an entry, has no name.
     static constexpr int RULE_INVALID_IDENTIFIER    { 2 };  //!< A name the generated code could not carry.

--- a/sources/lusan/model/sm/SMValidator.cpp
+++ b/sources/lusan/model/sm/SMValidator.cpp
@@ -46,17 +46,16 @@
 #include "lusan/data/common/DataTypeContainer.hpp"
 #include "lusan/data/common/DataTypeCustom.hpp"
 #include "lusan/data/common/DataTypeEnum.hpp"
-#include "lusan/data/common/DataTypeFactory.hpp"
 #include "lusan/data/common/DataTypeStructure.hpp"
 #include "lusan/data/common/FieldEntry.hpp"
 
 #include "lusan/model/sm/SMTypeCompat.hpp"
 #include "lusan/model/sm/SMGuardSymbols.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
 #include "lusan/model/common/LiteralValidator.hpp"
 
 #include <QCoreApplication>
 #include <QHash>
-#include <QRegularExpression>
 #include <QSet>
 
 namespace
@@ -166,6 +165,23 @@ namespace
                 ? eDocElementKind::Import : eDocElementKind::Include);
     }
 
+    //!< The numbers this engine has always filed the shared shapes under. An empty name is
+    //!< reported as the identifier fault it is, so both shapes carry rule 5 here.
+    const DocRuleChecks::RuleIds& smRules()
+    {
+        static const DocRuleChecks::RuleIds _rules
+        {
+              SMValidator::RULE_INVALID_IDENTIFIER
+            , SMValidator::RULE_INVALID_IDENTIFIER
+            , SMValidator::RULE_DUPLICATE_NAME
+            , SMValidator::RULE_UNRESOLVED_REFERENCE
+            , SMValidator::RULE_BAD_LITERAL
+            , SMValidator::RULE_UNREFERENCED
+        };
+
+        return _rules;
+    }
+
     /**
      * \class   Ctx
      * \brief   One validation run: holds the document, the accumulated findings, and the
@@ -175,7 +191,9 @@ namespace
     {
     public:
         explicit Ctx(const StateMachineData& data)
-            : mData(data)
+            : mData  (data)
+            , mIssues( )
+            , mChecks(mIssues, data.getDataTypes(), smRules())
         {
         }
 
@@ -188,9 +206,7 @@ namespace
         struct LevelInfo { const SMStateData* level; bool isRoot; uint32_t ownerId; };
         void collectLevels(const SMStateData& level, bool isRoot, uint32_t ownerId, QList<LevelInfo>& out) const;
 
-        void checkIdentifier(uint32_t id, eDocElementKind kind, const QString& name);
-        bool fragmentResolves(const QString& fragment) const;
-        QString unresolvedFragment(const QString& typeName) const;
+        void checkIdentifier(uint32_t id, eDocElementKind kind, const QString& name, const QString& what);
         void checkDataType(uint32_t id, eDocElementKind kind, const QString& typeName);
 
         void checkDuplicateIds();
@@ -242,20 +258,15 @@ namespace
     private:
         const StateMachineData& mData;
         QList<SMIssue>          mIssues;
+        DocRuleChecks           mChecks;    //!< The rules every document kind shares.
     };
 
     void Ctx::add(uint32_t id, eDocElementKind kind, eSeverity sev, int rule, const QString& message, const QString& detail)
     {
-        SMIssue issue;
-        issue.elementId = id;
-        issue.kind      = kind;
-        issue.severity  = sev;
-        issue.rule      = (sev != eSeverity::Error) ? (SMValidator::WARNING_RULE_BASE + rule) : rule;
-        issue.message   = message;
         // A check that explains itself keeps its own words; the rest fall back to what the rule
         // means, so a finding always reaches the results panel with a reason attached.
-        issue.detail    = detail.isEmpty() ? SMValidator::explainRule(issue.rule, sev) : detail;
-        mIssues.append(issue);
+        mChecks.add(id, kind, sev, rule, message
+                   , detail.isEmpty() ? SMValidator::explainRule(mChecks.ruleId(rule, sev), sev) : detail);
     }
 
     bool Ctx::hasParam(const MethodBase* owner, const QString& name) const
@@ -275,54 +286,16 @@ namespace
         }
     }
 
-    void Ctx::checkIdentifier(uint32_t id, eDocElementKind kind, const QString& name)
+    void Ctx::checkIdentifier(uint32_t id, eDocElementKind kind, const QString& name, const QString& what)
     {
-        if (StateMachineData::isValidIdentifier(name) == false)
-        {
-            add(id, kind, eSeverity::Error, 5, vtr("'%1' is not a valid identifier").arg(name));
-        }
-    }
-
-    bool Ctx::fragmentResolves(const QString& fragment) const
-    {
-        // Anything that is not a plain identifier after trimming is left alone. This is a type
-        // registry lookup, not a C++ parser.
-        if (StateMachineData::isValidIdentifier(fragment) == false)
-            return true;
-        if (DataTypeFactory::fromString(fragment) != DataTypeBase::eCategory::Undefined)
-            return true;
-        return (mData.getDataTypes().findCustomDataType(fragment) != nullptr);
-    }
-
-    QString Ctx::unresolvedFragment(const QString& typeName) const
-    {
-        // A templated type is the container name plus its arguments, and each of those must exist
-        // too. Checking only the whole string let `NEArray<Foo>` through with an undefined Foo.
-        const QStringList fragments = typeName.split(QRegularExpression(QStringLiteral("[<>,]")), Qt::SkipEmptyParts);
-        for (const QString& fragment : fragments)
-        {
-            const QString trimmed = fragment.trimmed();
-            if ((trimmed.isEmpty() == false) && (fragmentResolves(trimmed) == false))
-            {
-                return trimmed;
-            }
-        }
-
-        return QString();
+        mChecks.checkIdentifier(id, kind, name, what);
     }
 
     void Ctx::checkDataType(uint32_t id, eDocElementKind kind, const QString& typeName)
     {
-        if (typeName.isEmpty())
-            return;
-
-        // Report the offending fragment, not the whole string: "Foo does not resolve" is
-        // actionable, "NEMap<String, Foo> does not resolve" is not.
-        const QString unresolved = unresolvedFragment(typeName);
-        if (unresolved.isEmpty() == false)
-        {
-            add(id, kind, eSeverity::Error, 6, vtr("Data type '%1' does not resolve").arg(unresolved));
-        }
+        // A declaration with no type is left alone here: a condition that returns nothing and an
+        // untyped parameter are the concern of the checks that own those declarations.
+        mChecks.checkDeclaredType(id, kind, typeName, QString(), false);
     }
 
     void Ctx::collectIds(const SMStateData& level, QHash<uint32_t, int>& counts) const
@@ -428,73 +401,68 @@ namespace
     {
         // Names must be unique inside each registry, and triggers, events and timers share one
         // stimulus name space, so a name may belong to only one of them.
-        auto dupWithin = [this](const QStringList& names, const QList<uint32_t>& ids, eDocElementKind kind)
-        {
-            QHash<QString, int> seen;
-            for (int i = 0; i < names.size(); ++i)
-            {
-                if (names.at(i).isEmpty())
-                    continue;
-                if (++seen[names.at(i)] > 1)
-                    add(ids.at(i), kind, eSeverity::Error, 4, vtr("Duplicate name '%1' in registry").arg(names.at(i)));
-            }
-        };
 
         // Methods are unique per kind, not per name: a trigger, an action and a condition may all
-        // be called `on`. Qualifying the name with its kind expresses that.
-        QStringList mNames; QList<uint32_t> mIds;
+        // be called `on`. Keying the name by its kind expresses that.
+        DocNameSet methods(mChecks, eDocElementKind::Method);
         for (MethodEntry* m : mData.getMethods().getElements())
         {
             if (m != nullptr)
             {
-                mNames << (m->getType() + QLatin1Char(' ') + m->getName());
-                mIds << m->getId();
+                methods.claimKeyed(m->getId(), m->getType() + QLatin1Char(' ') + m->getName()
+                                  , vtr("%1 '%2'").arg(m->kind().label, m->getName()));
             }
         }
 
-        dupWithin(mNames, mIds, eDocElementKind::Method);
-
-        QStringList eNames; QList<uint32_t> eIds;
+        DocNameSet events(mChecks, eDocElementKind::Event);
         for (SMEventEntry* e : mData.getEvents().getElements())
-            if (e != nullptr) { eNames << e->getName(); eIds << e->getId(); }
-        dupWithin(eNames, eIds, eDocElementKind::Event);
+        {
+            if (e != nullptr)
+                events.claim(e->getId(), e->getName(), vtr("Event '%1'").arg(e->getName()));
+        }
 
-        QStringList tNames; QList<uint32_t> tIds;
-        for (const SMTimerEntry& t : mData.getTimers().getElements()) { tNames << t.getName(); tIds << t.getId(); }
-        dupWithin(tNames, tIds, eDocElementKind::Timer);
+        DocNameSet timers(mChecks, eDocElementKind::Timer);
+        for (const SMTimerEntry& t : mData.getTimers().getElements())
+            timers.claim(t.getId(), t.getName(), vtr("Timer '%1'").arg(t.getName()));
 
-        QStringList aNames; QList<uint32_t> aIds;
-        for (const AttributeEntry& a : mData.getAttributes().getElements()) { aNames << a.getName(); aIds << a.getId(); }
-        dupWithin(aNames, aIds, eDocElementKind::Attribute);
+        DocNameSet attributes(mChecks, eDocElementKind::Attribute);
+        for (const AttributeEntry& a : mData.getAttributes().getElements())
+            attributes.claim(a.getId(), a.getName(), vtr("Attribute '%1'").arg(a.getName()));
 
-        QStringList cNames; QList<uint32_t> cIds;
-        for (const ConstantEntry& c : mData.getConstants().getElements()) { cNames << c.getName(); cIds << c.getId(); }
-        dupWithin(cNames, cIds, eDocElementKind::Constant);
+        DocNameSet constants(mChecks, eDocElementKind::Constant);
+        for (const ConstantEntry& c : mData.getConstants().getElements())
+            constants.claim(c.getId(), c.getName(), vtr("Constant '%1'").arg(c.getName()));
 
         // The include registry is keyed by location, so getName() is the path -- the alias is the
         // registry name here, and collecting getName() would quietly check the wrong thing.
-        QStringList iNames; QList<uint32_t> iIds;
-        for (const IncludeEntry* i : mData.machineImports()) { iNames << i->getAlias(); iIds << i->getId(); }
-        dupWithin(iNames, iIds, eDocElementKind::Import);
+        DocNameSet imports(mChecks, eDocElementKind::Import);
+        for (const IncludeEntry* i : mData.machineImports())
+            imports.claim(i->getId(), i->getAlias(), vtr("Import '%1'").arg(i->getAlias()));
 
         // A file listed twice is redundant rather than wrong. The UI cannot create one, so this
-        // only fires on a hand-edited or merged file.
-        QHash<QString, int> seenLocations;
+        // only fires on a hand-edited or merged file. An include is keyed by its location, so the
+        // duplicate rule reads the path here.
+        QSet<QString> seenLocations;
         for (const IncludeEntry& i : mData.getIncludes().getElements())
         {
             if (i.getLocation().isEmpty())
                 continue;
-            if (++seenLocations[i.getLocation()] > 1)
+            if (seenLocations.contains(i.getLocation()))
             {
-                add(i.getId(), kindOfInclude(i), eSeverity::Warning, 4
-                    , vtr("'%1' is included more than once").arg(i.getLocation()));
+                mChecks.add(i.getId(), kindOfInclude(i), eSeverity::Warning, SMValidator::RULE_DUPLICATE_NAME
+                           , vtr("'%1' is included more than once").arg(i.getLocation())
+                           , DocRuleChecks::explainShape(DocRuleChecks::eShape::DuplicateName));
             }
+
+            seenLocations.insert(i.getLocation());
         }
 
-        QStringList dNames; QList<uint32_t> dIds;
+        DocNameSet dataTypes(mChecks, eDocElementKind::DataType);
         for (DataTypeCustom* d : mData.getDataTypes().getCustomDataTypes())
-            if (d != nullptr) { dNames << d->getName(); dIds << d->getId(); }
-        dupWithin(dNames, dIds, eDocElementKind::DataType);
+        {
+            if (d != nullptr)
+                dataTypes.claim(d->getId(), d->getName(), vtr("Data type '%1'").arg(d->getName()));
+        }
 
         // The shared stimulus name space: a name used by more than one of trigger/event/timer
         // is reported on each element after the first owner.
@@ -520,13 +488,10 @@ namespace
         auto dupParams = [this](const MethodBase* owner, eDocElementKind kind)
         {
             if (owner == nullptr) return;
-            QHash<QString, int> seen;
+            DocNameSet params(mChecks, kind);
             for (const MethodParameter& p : owner->getElements())
             {
-                if (p.getName().isEmpty())
-                    continue;
-                if (++seen[p.getName()] > 1)
-                    add(p.getId(), kind, eSeverity::Error, 4, vtr("Duplicate parameter name '%1'").arg(p.getName()));
+                params.claim(p.getId(), p.getName(), vtr("Parameter '%1' of '%2'").arg(p.getName(), owner->getName()));
             }
         };
         for (MethodEntry* m : mData.getMethods().getElements()) dupParams(m, eDocElementKind::Method);
@@ -569,7 +534,7 @@ namespace
     void Ctx::validateState(const SMStateEntry& state, const SMStateData& level, bool isRootLevel)
     {
         const uint32_t id = state.getId();
-        checkIdentifier(id, eDocElementKind::State, state.getName());
+        checkIdentifier(id, eDocElementKind::State, state.getName(), vtr("The state"));
 
         const bool composite = state.isComposite();
         const bool hasSubstates = composite;
@@ -1116,34 +1081,13 @@ namespace
 
     void Ctx::checkLiteral(uint32_t id, eDocElementKind kind, const QString& targetType, const QString& literal, int rule)
     {
-        // An absent literal is never a syntax error (a default may fill it).
-        if (literal.isEmpty())
-            return;
-
-        switch (categorize(targetType))
+        // An unresolved or imported type is not judged: the shared answer is silent on both, and
+        // the rule number stays this engine's because the caller picks the position it fills.
+        const QString reason = DocRuleChecks::literalReason(mData.getDataTypes(), targetType, literal);
+        if (reason.isEmpty() == false)
         {
-        case eTypeCat::Unknown:
-            return;
-        case eTypeCat::Structure:
-        case eTypeCat::Container:
-            add(id, kind, eSeverity::Error, rule, vtr("Type '%1' has no literal form").arg(targetType));
-            break;
-
-        case eTypeCat::Enum:
-        {
-            const DataTypeEnum* e = dynamic_cast<const DataTypeEnum*>(customType(targetType));
-            if ((e != nullptr) && (e->hasElement(literal) == false))
-                add(id, kind, eSeverity::Error, rule, vtr("'%1' is not an enumerator of '%2'").arg(literal, targetType));
-        }
-        break;
-
-        default:
-        {
-            const QString reason = LiteralValidator::validate(targetType, literal);
-            if (reason.isEmpty() == false)
-                add(id, kind, eSeverity::Error, rule, vtr("Invalid %1 literal '%2': %3").arg(targetType, literal, reason));
-        }
-        break;
+            add(id, kind, eSeverity::Error, rule, vtr("Invalid %1 literal '%2': %3").arg(targetType, literal, reason)
+               , DocRuleChecks::explainShape(DocRuleChecks::eShape::BadLiteral));
         }
     }
 
@@ -1271,7 +1215,7 @@ namespace
         for (MethodEntry* m : mData.getMethods().getElements())
         {
             if (m == nullptr) continue;
-            checkIdentifier(m->getId(), eDocElementKind::Method, m->getName());
+            checkIdentifier(m->getId(), eDocElementKind::Method, m->getName(), vtr("The %1").arg(m->kind().label.toLower()));
             // An embedded condition owns its body and must supply one; every other method has none.
             const bool embedded = NESMMethod::isCondition(m) && (m->getImplement() == MethodEntry::eImplement::Embedded);
             if (embedded && m->getBody().trimmed().isEmpty())
@@ -1291,21 +1235,21 @@ namespace
         for (SMEventEntry* e : mData.getEvents().getElements())
         {
             if (e == nullptr) continue;
-            checkIdentifier(e->getId(), eDocElementKind::Event, e->getName());
+            checkIdentifier(e->getId(), eDocElementKind::Event, e->getName(), vtr("The event"));
             for (const MethodParameter& p : e->getElements())
                 checkDataType(p.getId(), eDocElementKind::Event, p.getType());
             checkDefaultOrder(*e, eDocElementKind::Event, e->getName());
         }
         for (const SMTimerEntry& t : mData.getTimers().getElements())
-            checkIdentifier(t.getId(), eDocElementKind::Timer, t.getName());
+            checkIdentifier(t.getId(), eDocElementKind::Timer, t.getName(), vtr("The timer"));
         for (const AttributeEntry& a : mData.getAttributes().getElements())
         {
-            checkIdentifier(a.getId(), eDocElementKind::Attribute, a.getName());
+            checkIdentifier(a.getId(), eDocElementKind::Attribute, a.getName(), vtr("The attribute"));
             checkDataType(a.getId(), eDocElementKind::Attribute, a.getType());
         }
         for (const ConstantEntry& c : mData.getConstants().getElements())
         {
-            checkIdentifier(c.getId(), eDocElementKind::Constant, c.getName());
+            checkIdentifier(c.getId(), eDocElementKind::Constant, c.getName(), vtr("The constant"));
             checkDataType(c.getId(), eDocElementKind::Constant, c.getType());
         }
         for (const IncludeEntry* i : mData.machineImports())
@@ -1314,14 +1258,14 @@ namespace
                 add(i->getId(), eDocElementKind::Import, eSeverity::Error, 18
                     , vtr("Imported machine '%1' has no alias, so no state can host it").arg(i->getLocation()));
             else
-                checkIdentifier(i->getId(), eDocElementKind::Import, i->getAlias());
+                checkIdentifier(i->getId(), eDocElementKind::Import, i->getAlias(), vtr("The import"));
         }
         for (DataTypeCustom* d : mData.getDataTypes().getCustomDataTypes())
         {
             if (d == nullptr)
                 continue;
 
-            checkIdentifier(d->getId(), eDocElementKind::DataType, d->getName());
+            checkIdentifier(d->getId(), eDocElementKind::DataType, d->getName(), vtr("The data type"));
             // A composed type declares types of its own. Without this a structure field or a
             // container element could name a type nothing in the document defines, and the fault
             // only surfaced later, at whatever used the composed type.
@@ -2043,35 +1987,38 @@ namespace
             else if (NESMMethod::isCondition(m))  used = conditionsUsed.contains(m->getName());
             else if (NESMMethod::isTrigger(m))    used = triggersUsed.contains(m->getName());
             if (used == false)
-                add(m->getId(), eDocElementKind::Method, eSeverity::Warning, 4, vtr("Method '%1' is never referenced").arg(m->getName()));
+                mChecks.noteUnreferenced(m->getId(), eDocElementKind::Method, vtr("%1 '%2'").arg(m->kind().label, m->getName()), eSeverity::Warning);
         }
         for (SMEventEntry* e : mData.getEvents().getElements())
         {
             if (e == nullptr)
                 continue;
             if ((eventsSent.contains(e->getName()) == false) && (eventsReacted.contains(e->getName()) == false))
-                add(e->getId(), eDocElementKind::Event, eSeverity::Warning, 4, vtr("Event '%1' is never referenced").arg(e->getName()));
+                mChecks.noteUnreferenced(e->getId(), eDocElementKind::Event, vtr("Event '%1'").arg(e->getName()), eSeverity::Warning);
         }
         for (const SMTimerEntry& t : mData.getTimers().getElements())
         {
             if ((timersStarted.contains(t.getName()) == false) && (timersStopped.contains(t.getName()) == false) && (timersReacted.contains(t.getName()) == false))
-                add(t.getId(), eDocElementKind::Timer, eSeverity::Warning, 4, vtr("Timer '%1' is never referenced").arg(t.getName()));
+                mChecks.noteUnreferenced(t.getId(), eDocElementKind::Timer, vtr("Timer '%1'").arg(t.getName()), eSeverity::Warning);
         }
         for (const ConstantEntry& c : mData.getConstants().getElements())
         {
             if (constsUsed.contains(c.getName()) == false)
-                add(c.getId(), eDocElementKind::Constant, eSeverity::Info, 4, vtr("Constant '%1' is never referenced").arg(c.getName()));
+                mChecks.noteUnreferenced(c.getId(), eDocElementKind::Constant, vtr("Constant '%1'").arg(c.getName()), eSeverity::Info);
         }
         for (const IncludeEntry* i : mData.machineImports())
         {
             // An import is always another `.fsml` machine brought in to serve as a submachine
             if ((i->getAlias().isEmpty() == false) && (importsUsed.contains(i->getAlias()) == false))
-                add(i->getId(), eDocElementKind::Import, eSeverity::Warning, 4, vtr("Import '%1' is never used as a submachine").arg(i->getAlias()));
+            {
+                mChecks.noteUnreferenced(i->getId(), eDocElementKind::Import, QString(), eSeverity::Warning
+                                        , vtr("Import '%1' is never used as a submachine").arg(i->getAlias()));
+            }
         }
         for (DataTypeCustom* d : mData.getDataTypes().getCustomDataTypes())
         {
             if ((d != nullptr) && (typesUsed.contains(d->getName()) == false))
-                add(d->getId(), eDocElementKind::DataType, eSeverity::Warning, 4, vtr("Data type '%1' is never referenced").arg(d->getName()));
+                mChecks.noteUnreferenced(d->getId(), eDocElementKind::DataType, vtr("Data type '%1'").arg(d->getName()), eSeverity::Warning);
         }
 
         // Warning 5: an event reacted to but never sent, or sent but never reacted to.
@@ -2108,7 +2055,8 @@ QString SMValidator::explainRule(int rule, DocIssue::eSeverity severity)
         case 1:  return vtr("The state cannot be reached by any transition, so its behaviour never runs.");
         case 2:  return vtr("The state has no way out. Once the machine enters it, it stays there.");
         case 3:  return vtr("An earlier transition on the same stimulus always fires, so this one never gets its turn.");
-        case 4:  return vtr("Nothing in the machine uses this declaration. Keep it if you are about to, or remove it.");
+        case SMValidator::RULE_UNREFERENCED:
+            return DocRuleChecks::explainShape(DocRuleChecks::eShape::Unreferenced);
         case 5:  return vtr("Only one half of the event is here. An event needs something that sends it and a transition that reacts to it.");
         case 6:  return vtr("Only one half of the timer is here. A timer needs something that starts it and a transition that reacts to it.");
         case 7:  return vtr("The transition reacts to the stimulus and then does nothing with it, so it has no visible effect.");
@@ -2123,9 +2071,12 @@ QString SMValidator::explainRule(int rule, DocIssue::eSeverity severity)
     case 1:  return vtr("Every machine level needs exactly one Start state; it marks where execution begins.");
     case 2:  return vtr("A level may declare only one Start state, otherwise the entry point is ambiguous.");
     case 3:  return vtr("A Final state is terminal and cannot have outgoing transitions.");
-    case 4:  return vtr("Two entries of the same kind share this name. Names are unique per kind, so a trigger, an action and a condition may all be called the same, but two triggers may not.");
-    case 5:  return vtr("Identifiers must be usable in generated code: a letter or underscore first, then letters, digits or underscores.");
-    case 6:  return vtr("The name is referenced here but declared nowhere of that kind. Check the spelling, and check the kind: an action and a trigger of the same name are different declarations.");
+    case SMValidator::RULE_DUPLICATE_NAME:
+        return DocRuleChecks::explainShape(DocRuleChecks::eShape::DuplicateName);
+    case SMValidator::RULE_INVALID_IDENTIFIER:
+        return DocRuleChecks::explainShape(DocRuleChecks::eShape::InvalidIdentifier);
+    case SMValidator::RULE_UNRESOLVED_REFERENCE:
+        return vtr("The name is referenced here but declared nowhere of that kind. Check the spelling, and check the kind: an action and a trigger of the same name are different declarations.");
     case 7:  return vtr("A transition may only target a state of its own level. Cross-level jumps go through the parent.");
     case 8:  return vtr("Every element ID must be unique in the document; a repeat breaks layout and reference tracking.");
     case 9:  return vtr("Start and Final are pseudo-states: they mark entry and termination and cannot own substates or a submachine.");

--- a/sources/lusan/model/sm/SMValidator.hpp
+++ b/sources/lusan/model/sm/SMValidator.hpp
@@ -23,6 +23,7 @@
  * Includes
  ************************************************************************/
 #include "lusan/model/common/DocIssue.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
 
 #include <QList>
 #include <QString>
@@ -63,7 +64,7 @@ public:
     /**
      * \brief   A warning `n` is reported with the rule id (`WARNING_RULE_BASE + n`)
      **/
-    static constexpr int WARNING_RULE_BASE { 100 };
+    static constexpr int WARNING_RULE_BASE { DocRuleChecks::ADVISORY_RULE_BASE };
 
     /**
      * \brief   An information `n` is reported with the rule id (`INFORMATION_RULE_BASE + n`).
@@ -88,9 +89,31 @@ public:
 
     /**
      * \brief   A name the generated code could not carry: it must start with a letter or an
-     *          underscore and continue with letters, digits or underscores.
+     *          underscore and continue with letters, digits or underscores. A declaration with
+     *          no name at all is the same fault and carries the same number.
      **/
     static constexpr int RULE_INVALID_IDENTIFIER { 5 };
+
+    /**
+     * \brief   A name referenced here and declared nowhere of that kind: a target, a stimulus,
+     *          an action, a timer, an event, an attribute, a constant, a condition operand, or
+     *          a declared data type.
+     **/
+    static constexpr int RULE_UNRESOLVED_REFERENCE { 6 };
+
+    /**
+     * \brief   A value that does not read as its declared type: a malformed literal, a name
+     *          that is not an enumerator of its enumeration, or a literal on a type that has
+     *          no literal form.
+     **/
+    static constexpr int RULE_BAD_LITERAL { 15 };
+
+    /**
+     * \brief   Advisory: nothing in the machine uses the declaration. Reported in the advisory
+     *          band, so the emitted id is `WARNING_RULE_BASE + RULE_UNREFERENCED` and never
+     *          the bare number, which belongs to \a RULE_DUPLICATE_NAME.
+     **/
+    static constexpr int RULE_UNREFERENCED { 4 };
 
     /**
      * \brief   An element with no description. Advisory: the document still generates, but the

--- a/sources/lusan/view/common/AttributePage.cpp
+++ b/sources/lusan/view/common/AttributePage.cpp
@@ -29,7 +29,7 @@
 #include "lusan/model/common/AttributeModel.hpp"
 #include "lusan/model/common/DocModelNotifier.hpp"
 #include "lusan/model/common/IEDocumentModel.hpp"
-#include "lusan/model/common/LiteralValidator.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
 #include "lusan/view/common/AttributeDetailsView.hpp"
 #include "lusan/view/common/PendingEditWatcher.hpp"
 #include "lusan/view/common/WidgetHighlight.hpp"
@@ -393,27 +393,9 @@ void AttributePage::updateValueControl(const AttributeEntry* entry)
 
 QString AttributePage::valueValidationReason(const QString& typeName, const QString& value) const
 {
-    // No default is always valid - a missing value simply means "not set", not "invalid".
-    if (value.isEmpty())
-        return QString();
-
-    DataTypeCustom* custom = findCustomType(typeName);
-    if (custom != nullptr)
-    {
-        if (custom->getCategory() == DataTypeBase::eCategory::Enumeration)
-        {
-            if (static_cast<DataTypeEnum*>(custom)->findElement(value) == nullptr)
-            {
-                return tr("'%1' is not an enumerator of '%2'").arg(value, typeName);
-            }
-        }
-
-        // Structure/Container: the value control is disabled, never reaches here.
-        // Imported: the type is opaque to Lusan - accept any literal as-is.
-        return QString();
-    }
-
-    return LiteralValidator::validate(typeName, value);
+    // The same answer the validation engine gives, so the hint under the field and the finding
+    // in the results panel can never disagree.
+    return DocRuleChecks::literalReason(mModel.getDocument().getDataTypeSection(), typeName, value);
 }
 
 void AttributePage::updateValueValidation(const QString& typeName, const QString& value)

--- a/sources/lusan/view/common/ConstantPage.cpp
+++ b/sources/lusan/view/common/ConstantPage.cpp
@@ -29,7 +29,7 @@
 #include "lusan/model/common/ConstantModel.hpp"
 #include "lusan/model/common/DocModelNotifier.hpp"
 #include "lusan/model/common/IEDocumentModel.hpp"
-#include "lusan/model/common/LiteralValidator.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
 #include "lusan/view/common/ConstantDetailsView.hpp"
 #include "lusan/view/common/ConstantListView.hpp"
 #include "lusan/view/common/PendingEditWatcher.hpp"
@@ -323,27 +323,9 @@ void ConstantPage::updateValueControl(const ConstantEntry* entry)
 
 QString ConstantPage::valueValidationReason(const QString& typeName, const QString& value) const
 {
-    // No value is always valid - a missing literal simply means "not set", not "invalid".
-    if (value.isEmpty())
-        return QString();
-
-    DataTypeCustom* custom = findCustomType(typeName);
-    if (custom != nullptr)
-    {
-        if (custom->getCategory() == DataTypeBase::eCategory::Enumeration)
-        {
-            if (static_cast<DataTypeEnum*>(custom)->findElement(value) == nullptr)
-            {
-                return tr("'%1' is not an enumerator of '%2'").arg(value, typeName);
-            }
-        }
-
-        // Structure/Container: the value control is disabled, never reaches here.
-        // Imported: the type is opaque to Lusan - accept any literal as-is.
-        return QString();
-    }
-
-    return LiteralValidator::validate(typeName, value);
+    // The same answer the validation engine gives, so the hint under the field and the finding
+    // in the results panel can never disagree.
+    return DocRuleChecks::literalReason(mModel.getDocument().getDataTypeSection(), typeName, value);
 }
 
 void ConstantPage::updateValueValidation(const QString& typeName, const QString& value)

--- a/sources/lusan/view/common/DataTypePage.cpp
+++ b/sources/lusan/view/common/DataTypePage.cpp
@@ -32,7 +32,7 @@
 #include "lusan/data/common/FieldEntry.hpp"
 #include "lusan/model/common/DataTypeModel.hpp"
 #include "lusan/model/common/DocModelNotifier.hpp"
-#include "lusan/model/common/LiteralValidator.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
 #include "lusan/view/common/DataTypeDetailsView.hpp"
 #include "lusan/view/common/DataTypeFieldDetailsView.hpp"
 #include "lusan/view/common/DataTypeListView.hpp"
@@ -666,12 +666,9 @@ QTreeWidgetItem* DataTypePage::createNode(DataTypeCustom* dataType) const
 
 QString DataTypePage::validateFieldValue(const QString& typeName, const QString& value) const
 {
-    // No default is always valid, and a declared (enum/structure/container/imported) type is
-    // ignored - its literal form, if any, is not this validator's concern.
-    if (value.isEmpty() || (mModel.findDataType(typeName) != nullptr))
-        return QString();
-
-    return LiteralValidator::validate(typeName, value);
+    // The same answer the validation engine gives, so the marker on the row and the finding in
+    // the results panel can never disagree.
+    return DocRuleChecks::literalReason(mModel.getDocument().getDataTypeSection(), typeName, value);
 }
 
 QString DataTypePage::validateDeclaredType(const FieldEntry& field)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ qt_add_executable(lusan_sm_validation_tests
     ${LUSAN}/model/sm/SMOperationValidation.cpp
     ${LUSAN}/model/sm/SMGuardSymbols.cpp
     ${LUSAN}/model/sm/SMTypeCompat.cpp
+    ${LUSAN}/model/common/DocRuleChecks.cpp
     ${LUSAN}/model/common/LiteralValidator.cpp
     ${LUSAN_ROOT}/tests/sm/SMValidationTests.cpp
     # Enumeration literal checks (rule 15) load the basic-container/predefined type catalog.
@@ -197,6 +198,7 @@ qt_add_executable(lusan_sm_command_tests
     ${LUSAN}/model/sm/SMGuardValidation.cpp
     ${LUSAN}/model/sm/SMOperationValidation.cpp
     ${LUSAN}/model/sm/SMTypeCompat.cpp
+    ${LUSAN}/model/common/DocRuleChecks.cpp
     ${LUSAN}/model/common/LiteralValidator.cpp
     ${LUSAN_ROOT}/tests/sm/SMCommandTests.cpp
     # Container tests need the real basic-container catalog (Array/HashMap/Map/...): it is
@@ -252,6 +254,7 @@ qt_add_executable(lusan_sm_mapping_tests
     ${LUSAN}/model/sm/SMArgumentCommands.cpp
     ${LUSAN}/model/sm/SMMappingSources.cpp
     ${LUSAN}/model/sm/SMTypeCompat.cpp
+    ${LUSAN}/model/common/DocRuleChecks.cpp
     ${LUSAN}/model/common/LiteralValidator.cpp
     ${LUSAN}/model/sm/SMOperationValidation.cpp
     ${LUSAN}/view/sm/NEGuardStyle.cpp
@@ -423,6 +426,7 @@ set(LUSAN_DESIGN_PAGE_SRC
     ${LUSAN}/model/sm/SMRenameCommands.cpp
     ${LUSAN}/model/sm/SMConditionText.cpp
     ${LUSAN}/model/sm/SMLayoutCommands.cpp
+    ${LUSAN}/model/common/DocRuleChecks.cpp
     ${LUSAN}/model/common/LiteralValidator.cpp
     ${LUSAN}/model/sm/SMPasteCommand.cpp
     ${LUSAN}/model/sm/SMStateCommands.cpp
@@ -634,6 +638,7 @@ set(LUSAN_GUARD_UI_SRC
     ${LUSAN}/model/sm/SMRenameCommands.cpp
     ${LUSAN}/model/sm/SMConditionText.cpp
     ${LUSAN}/model/sm/SMLayoutCommands.cpp
+    ${LUSAN}/model/common/DocRuleChecks.cpp
     ${LUSAN}/model/common/LiteralValidator.cpp
     ${LUSAN}/model/sm/SMPasteCommand.cpp
     ${LUSAN}/model/sm/SMStateCommands.cpp
@@ -865,6 +870,7 @@ qt_add_executable(lusan_si_command_tests
     ${LUSAN_CMD_COMMON_SRC}
     ${LUSAN}/model/si/SICommand.cpp
     ${LUSAN}/model/si/SIValidator.cpp
+    ${LUSAN}/model/common/DocRuleChecks.cpp
     ${LUSAN}/model/common/LiteralValidator.cpp
     ${LUSAN_ROOT}/tests/si/SICommandTests.cpp
     # Resolving a declared type against the primitive and basic-container catalogs needs the real

--- a/tests/si/SICommandTests.cpp
+++ b/tests/si/SICommandTests.cpp
@@ -38,6 +38,9 @@
 #include "lusan/data/common/MethodParameter.hpp"
 #include "lusan/data/common/MethodDataSection.hpp"
 #include "lusan/model/si/SIValidator.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
+#include "lusan/common/NELusanCommon.hpp"
+#include "lusan/data/common/DataTypeEnum.hpp"
 
 #include <QUndoStack>
 #include <QXmlStreamReader>
@@ -714,6 +717,25 @@ namespace
         return count;
     }
 
+    //!< True when the rule was reported at all, and every finding of it carries the one
+    //!< explanation the shape has.
+    bool explains(const QList<DocIssue>& issues, int rule, DocRuleChecks::eShape shape)
+    {
+        const QString expected = DocRuleChecks::explainShape(shape);
+        int found = 0;
+        for (const DocIssue& issue : issues)
+        {
+            if (issue.rule != rule)
+                continue;
+            if (issue.detail != expected)
+                return false;
+
+            ++found;
+        }
+
+        return (found > 0);
+    }
+
     //!< True when some finding carries the rule and quotes the text.
     bool namesIt(const QList<DocIssue>& issues, int rule, const QString& text)
     {
@@ -930,6 +952,87 @@ namespace
             CHECK(allExplained);
         }
     }
+
+    //!< The rule shapes both document engines share now come from one place: the same answer,
+    //!< the same wording and the same explanation, filed under the number this engine has
+    //!< always used. The state machine side asserts the same explanations.
+    void testValidatorSharedShapes()
+    {
+        {   // A declared enumeration has a literal form of its own: its enumerators. Before the
+            // shapes were shared the service interface skipped every declared type here.
+            ServiceInterfaceData doc;
+            makeUsable(doc);
+            DataTypeEnum* colors = doc.getDataTypeData().addEnum(QStringLiteral("Color"));
+            CHECK(colors != nullptr);
+            CHECK(colors->addField(QStringLiteral("Red")) != nullptr);
+            CHECK(colors->addField(QStringLiteral("Green")) != nullptr);
+
+            ConstantEntry* wrong = doc.getConstantData().createConstant(QStringLiteral("Accent"));
+            CHECK(wrong != nullptr);
+            wrong->setType(QStringLiteral("Color"));
+            wrong->setValue(QStringLiteral("Blue"));
+
+            QList<DocIssue> issues = SIValidator::validate(doc);
+            CHECK(countRule(issues, SIValidator::RULE_BAD_LITERAL) == 1);
+            CHECK(namesIt(issues, SIValidator::RULE_BAD_LITERAL, QStringLiteral("enumerator")));
+
+            // The same constant with a declared enumerator is silent.
+            wrong->setValue(QStringLiteral("Green"));
+            CHECK(countRule(SIValidator::validate(doc), SIValidator::RULE_BAD_LITERAL) == 0);
+        }
+
+        {   // A structure carries no literal at all, and a name longer than a compiler would
+            // take is the identifier fault it is.
+            ServiceInterfaceData doc;
+            makeUsable(doc);
+            DataTypeStructure* record = doc.getDataTypeData().addStructure(QStringLiteral("Record"));
+            CHECK(record != nullptr);
+            record->addField(QStringLiteral("id"))->setType(QStringLiteral("uint32"));
+
+            ConstantEntry* bad = doc.getConstantData().createConstant(QStringLiteral("Seed"));
+            CHECK(bad != nullptr);
+            bad->setType(QStringLiteral("Record"));
+            bad->setValue(QStringLiteral("0"));
+
+            AttributeEntry* longName = doc.getAttributeData().createAttribute(QStringLiteral("counter"));
+            CHECK(longName != nullptr);
+            longName->setType(QStringLiteral("uint32"));
+            longName->setName(QString(NELusanCommon::MAX_IDENTIFIER_LENGTH + 1, QLatin1Char('a')));
+
+            const QList<DocIssue> issues = SIValidator::validate(doc);
+            CHECK(countRule(issues, SIValidator::RULE_BAD_LITERAL) == 1);
+            CHECK(namesIt(issues, SIValidator::RULE_BAD_LITERAL, QStringLiteral("no literal form")));
+            CHECK(countRule(issues, SIValidator::RULE_INVALID_IDENTIFIER) == 1);
+        }
+
+        {   // One shape, one explanation: a finding of a shared shape carries the shared text,
+            // whichever document it came from, so the results panel cannot describe one defect
+            // two ways.
+            ServiceInterfaceData doc;
+            makeUsable(doc);
+            AttributeEntry* unnamed = doc.getAttributeData().createAttribute(QStringLiteral("temporary"));
+            CHECK(unnamed != nullptr);
+            unnamed->setType(QStringLiteral("Missing"));
+            unnamed->setName(QString());
+
+            ConstantEntry* twice = doc.getConstantData().createConstant(QStringLiteral("Limit"));
+            CHECK(twice != nullptr);
+            twice->setType(QStringLiteral("uint32"));
+            twice->setValue(QStringLiteral("nine"));
+            ConstantEntry* clash = doc.getConstantData().createConstant(QStringLiteral("Other"));
+            CHECK(clash != nullptr);
+            clash->setType(QStringLiteral("uint32"));
+            clash->setName(QStringLiteral("Limit"));
+
+            const int unreferenced = SIValidator::ADVISORY_RULE_BASE + SIValidator::RULE_UNREFERENCED;
+            const QList<DocIssue> issues = SIValidator::validate(doc);
+            CHECK(explains(issues, SIValidator::RULE_MISSING_NAME, DocRuleChecks::eShape::MissingName));
+            CHECK(explains(issues, SIValidator::RULE_UNRESOLVED_TYPE, DocRuleChecks::eShape::UnresolvedType));
+            CHECK(explains(issues, SIValidator::RULE_DUPLICATE_NAME, DocRuleChecks::eShape::DuplicateName));
+            CHECK(explains(issues, SIValidator::RULE_BAD_LITERAL, DocRuleChecks::eShape::BadLiteral));
+            CHECK(explains(issues, unreferenced, DocRuleChecks::eShape::Unreferenced));
+        }
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -953,6 +1056,7 @@ int main(int /*argc*/, char* /*argv*/[])
     testValidatorUnreferenced();
     testValidatorUnusedImport();
     testValidatorDeclarations();
+    testValidatorSharedShapes();
 
     std::printf("Checks: %d, Failures: %d\n", gChecks, gFailures);
     return (gFailures == 0 ? 0 : 1);

--- a/tests/sm/SMValidationTests.cpp
+++ b/tests/sm/SMValidationTests.cpp
@@ -21,6 +21,8 @@
  ************************************************************************/
 
 #include "lusan/model/sm/SMValidator.hpp"
+#include "lusan/model/common/DocRuleChecks.hpp"
+#include "lusan/common/NELusanCommon.hpp"
 #include "lusan/model/sm/SMTypeCompat.hpp"
 #include "lusan/model/sm/SMOperationValidation.hpp"
 
@@ -2831,6 +2833,98 @@ namespace
     }
 }
 
+namespace
+{
+    //!< True when the rule was reported at all, and every finding of it carries the one
+    //!< explanation the shape has. The service interface tests assert the same texts, so a
+    //!< defect both engines can find is described once.
+    bool explains(const QList<SMIssue>& issues, int rule, DocRuleChecks::eShape shape)
+    {
+        const QString expected = DocRuleChecks::explainShape(shape);
+        int found = 0;
+        for (const SMIssue& issue : issues)
+        {
+            if (issue.rule != rule)
+                continue;
+            if (issue.detail != expected)
+                return false;
+
+            ++found;
+        }
+
+        return (found > 0);
+    }
+
+    //!< The rule shapes both document engines share now come from one place. The numbers are
+    //!< unchanged -- the emitted id is what an author reads and what the generator files under.
+    void testSharedRuleShapes()
+    {
+        std::printf("- shared rule shapes: one answer, one wording, this engine's numbers\n");
+
+        {   // A name no compiler would take is the identifier fault, and the bound is the one
+            // every editor field caps at.
+            StateMachineData doc;
+            addStart(doc);
+            doc.getAttributes().createAttribute(QString(NELusanCommon::MAX_IDENTIFIER_LENGTH + 1, QLatin1Char('a')))
+                              ->setType(QStringLiteral("uint32"));
+            CHECK(countRule(SMValidator::validate(doc), SMValidator::RULE_INVALID_IDENTIFIER) == 1);
+        }
+
+        {   // A declaration with no name at all is the same fault under the same number, and it
+            // now says what is missing instead of quoting an empty string.
+            StateMachineData doc;
+            addStart(doc);
+            doc.getConstants().createConstant(QString());
+
+            const QList<SMIssue> issues = SMValidator::validate(doc);
+            CHECK(countRule(issues, SMValidator::RULE_INVALID_IDENTIFIER) == 1);
+            bool saysMissing = false;
+            for (const SMIssue& issue : issues)
+            {
+                saysMissing = saysMissing || ((issue.rule == SMValidator::RULE_INVALID_IDENTIFIER)
+                                              && issue.message.contains(QStringLiteral("has no name")));
+            }
+
+            CHECK(saysMissing);
+        }
+
+        {   // A duplicate name names the entry the author has to rename, whichever registry it
+            // is in, and keeps its number.
+            StateMachineData doc;
+            addStart(doc);
+            doc.getAttributes().createAttribute(QStringLiteral("speed"))->setType(QStringLiteral("uint32"));
+            AttributeEntry* clash = doc.getAttributes().createAttribute(QStringLiteral("velocity"));
+            CHECK(clash != nullptr);
+            clash->setType(QStringLiteral("uint32"));
+            clash->setName(QStringLiteral("speed"));
+
+            const QList<SMIssue> issues = SMValidator::validate(doc);
+            CHECK(countRule(issues, SMValidator::RULE_DUPLICATE_NAME) == 1);
+            bool namesIt = false;
+            for (const SMIssue& issue : issues)
+            {
+                namesIt = namesIt || ((issue.rule == SMValidator::RULE_DUPLICATE_NAME)
+                                      && issue.message.contains(QStringLiteral("Attribute 'speed'")));
+            }
+
+            CHECK(namesIt);
+        }
+
+        {   // One shape, one explanation. Both engines attach the shared text to the shared
+            // shapes, so the results panel cannot describe one defect two ways.
+            StateMachineData doc;
+            addStart(doc);
+            doc.getAttributes().createAttribute(QStringLiteral("shape"))->setType(QStringLiteral("Missing"));
+            doc.getConstants().createConstant(QStringLiteral("Unused"))->setType(QStringLiteral("uint32"));
+
+            const QList<SMIssue> issues = SMValidator::validate(doc);
+            CHECK(explains(issues, SMValidator::RULE_UNRESOLVED_REFERENCE, DocRuleChecks::eShape::UnresolvedType));
+            CHECK(explains(issues, SMValidator::WARNING_RULE_BASE + SMValidator::RULE_UNREFERENCED
+                          , DocRuleChecks::eShape::Unreferenced));
+        }
+    }
+}
+
 int main(int /*argc*/, char* /*argv*/[])
 {
     std::printf("=== FSM validation engine tests ===\n");
@@ -2865,6 +2959,7 @@ int main(int /*argc*/, char* /*argv*/[])
     testIncludeRegistry();
     testDataTypeGaps();
     testDefaultOrderAndCallableNames();
+    testSharedRuleShapes();
 
     std::printf("=== %d checks, %d failure(s) ===\n", gChecks, gFailures);
     return (gFailures == 0) ? 0 : 1;


### PR DESCRIPTION
Unified validation

- SI gains literal checking against declared types — an enum constant could previously hold any text at all — and the 255-char name bound the fields already enforced.
- FSM gains "The constant has no name" instead of '' is not a valid identifier, "Trigger 'go' is declared more than once" instead of Duplicate name 'trigger go' in registry.