### PR TITLE
fix: keep the Attribute and Constant name in edit mode while typing in the list

### DIFF
--- a/sources/lusan/view/common/AttributePage.cpp
+++ b/sources/lusan/view/common/AttributePage.cpp
@@ -229,9 +229,14 @@ void AttributePage::setupSignals(void)
 
     // A commit from an inline editor rebuilds the list. Let the delegate close first.
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &AttributePage::onEditorDataChanged, Qt::QueuedConnection);
-    // Live-preview the name typed in a list cell into the details Name field, the mirror image of
-    // what the details field does to the list row. It commits nothing, so the editor stays open.
+    // Live-preview what is typed in a list cell into the matching details field, the mirror image
+    // of what the details fields do to the list row. It commits nothing, so the editor stays open.
     connect(mTableCell, &TableCell::signalEditorTextChanged, this, &AttributePage::onEditorTextChanged);
+    // An edit can end without committing anything: an emptied cell is refused, and Escape cancels.
+    // Rebuilding once the editor is gone puts the row and the previewed details back to what the
+    // model actually holds. Queued, so the view has finished with the editor, and so a commit that
+    // is on its way is applied on top.
+    connect(mTableCell, &QAbstractItemDelegate::closeEditor, this, [this]() { refreshAll(); }, Qt::QueuedConnection);
 
     // The shared view already installs the C++ identifier validator on the Name field.
     connect(mDetails->ctrlName(), &QLineEdit::editingFinished, this, &AttributePage::onNameCommitted);
@@ -787,16 +792,31 @@ void AttributePage::onEditorTextChanged(const QModelIndex& index, const QString&
 {
     QTreeWidget* table = mList->ctrlTableList();
     QTreeWidgetItem* item = table->topLevelItem(index.row());
-    if ((index.column() != static_cast<int>(AttributeListView::eColumn::ColName))
-        || (item == nullptr) || (item != table->currentItem()))
-    {
+    if ((item == nullptr) || (item != table->currentItem()))
         return;
-    }
 
-    // Blocked: the field re-emits its text as nameEdited, which would write it straight back into
-    // the row whose editor is open.
-    const QSignalBlocker blockName(mDetails->ctrlName());
-    mDetails->ctrlName()->setText(newText);
+    // The row itself is deliberately left alone: writing to the cell under an open editor makes
+    // the view re-seed that editor from the cell, which would wipe what is being typed. The
+    // editor covers the cell anyway, so only the details panel has anything to show.
+    if (index.column() == static_cast<int>(AttributeListView::eColumn::ColName))
+    {
+        // Blocked: the field re-emits its text as nameEdited, which would write it straight back
+        // into the row whose editor is open.
+        const QSignalBlocker blockName(mDetails->ctrlName());
+        mDetails->ctrlName()->setText(newText);
+    }
+    else if (hasValueColumn() && (index.column() == static_cast<int>(AttributeListView::eColumn::ColExtra)))
+    {
+        const AttributeEntry* entry = mModel.findAttribute(currentAttributeId());
+        if (entry == nullptr)
+            return;
+
+        const QSignalBlocker blockValue(mDetails->ctrlValue());
+        mDetails->ctrlValue()->setText(newText);
+        // The literal is judged as it is typed, exactly as it is when the details Value field is
+        // the one being typed in.
+        updateValueValidation(entry->getType(), newText);
+    }
 }
 
 void AttributePage::refreshAll(void)

--- a/sources/lusan/view/common/AttributePage.cpp
+++ b/sources/lusan/view/common/AttributePage.cpp
@@ -154,7 +154,9 @@ void AttributePage::buildUi(const QString& headline)
         pickerColumns.append(colExtra);
     }
 
-    mTableCell = new TableCell(pickers, pickerColumns, table, this, false);
+    // The inline editors commit when the edit is done, not per keystroke: a commit rebuilds the
+    // list, which would tear the open editor down after the first character typed.
+    mTableCell = new TableCell(pickers, pickerColumns, table, this, true);
     mTableCell->setColumnValidation(static_cast<int>(AttributeListView::eColumn::ColName), TableCell::eCellValidation::Identifier);
 
     if (hasValueColumn())
@@ -227,6 +229,9 @@ void AttributePage::setupSignals(void)
 
     // A commit from an inline editor rebuilds the list. Let the delegate close first.
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &AttributePage::onEditorDataChanged, Qt::QueuedConnection);
+    // Live-preview the name typed in a list cell into the details Name field, the mirror image of
+    // what the details field does to the list row. It commits nothing, so the editor stays open.
+    connect(mTableCell, &TableCell::signalEditorTextChanged, this, &AttributePage::onEditorTextChanged);
 
     // The shared view already installs the C++ identifier validator on the Name field.
     connect(mDetails->ctrlName(), &QLineEdit::editingFinished, this, &AttributePage::onNameCommitted);
@@ -776,6 +781,22 @@ void AttributePage::onEditorDataChanged(const QModelIndex& index, const QString&
 
     // The commit above rebuilt the list; put the details panel back on the edited row.
     selectAttribute(id);
+}
+
+void AttributePage::onEditorTextChanged(const QModelIndex& index, const QString& newText)
+{
+    QTreeWidget* table = mList->ctrlTableList();
+    QTreeWidgetItem* item = table->topLevelItem(index.row());
+    if ((index.column() != static_cast<int>(AttributeListView::eColumn::ColName))
+        || (item == nullptr) || (item != table->currentItem()))
+    {
+        return;
+    }
+
+    // Blocked: the field re-emits its text as nameEdited, which would write it straight back into
+    // the row whose editor is open.
+    const QSignalBlocker blockName(mDetails->ctrlName());
+    mDetails->ctrlName()->setText(newText);
 }
 
 void AttributePage::refreshAll(void)

--- a/sources/lusan/view/common/AttributePage.cpp
+++ b/sources/lusan/view/common/AttributePage.cpp
@@ -229,19 +229,11 @@ void AttributePage::setupSignals(void)
 
     // A commit from an inline editor rebuilds the list. Let the delegate close first.
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &AttributePage::onEditorDataChanged, Qt::QueuedConnection);
-    // Live-preview what is typed in a list cell into the matching details field, the mirror image
-    // of what the details fields do to the list row. It commits nothing, so the editor stays open.
     connect(mTableCell, &TableCell::signalEditorTextChanged, this, &AttributePage::onEditorTextChanged);
-    // An edit can end without committing anything: an emptied cell is refused, and Escape cancels.
-    // Rebuilding once the editor is gone puts the row and the previewed details back to what the
-    // model actually holds. Queued, so the view has finished with the editor, and so a commit that
-    // is on its way is applied on top.
-    connect(mTableCell, &QAbstractItemDelegate::closeEditor, this, [this]() { refreshAll(); }, Qt::QueuedConnection);
+    connect(mTableCell, &TableCell::signalEditorClosed     , this, &AttributePage::onEditorClosed);
 
     // The shared view already installs the C++ identifier validator on the Name field.
     connect(mDetails->ctrlName(), &QLineEdit::editingFinished, this, &AttributePage::onNameCommitted);
-    // Live-preview the typed name into the selected attribute's Name column; the rename commits on
-    // editingFinished. Selection sets the field under a QSignalBlocker.
     connect(mDetails, &AttributeDetailsView::nameEdited, this, [this](const QString& text) {
         if (currentAttributeId() != 0)
         {
@@ -795,13 +787,9 @@ void AttributePage::onEditorTextChanged(const QModelIndex& index, const QString&
     if ((item == nullptr) || (item != table->currentItem()))
         return;
 
-    // The row itself is deliberately left alone: writing to the cell under an open editor makes
-    // the view re-seed that editor from the cell, which would wipe what is being typed. The
-    // editor covers the cell anyway, so only the details panel has anything to show.
     if (index.column() == static_cast<int>(AttributeListView::eColumn::ColName))
     {
-        // Blocked: the field re-emits its text as nameEdited, which would write it straight back
-        // into the row whose editor is open.
+        // Blocked: the field re-emits its text as nameEdited, which writes it back into the row.
         const QSignalBlocker blockName(mDetails->ctrlName());
         mDetails->ctrlName()->setText(newText);
     }
@@ -813,10 +801,13 @@ void AttributePage::onEditorTextChanged(const QModelIndex& index, const QString&
 
         const QSignalBlocker blockValue(mDetails->ctrlValue());
         mDetails->ctrlValue()->setText(newText);
-        // The literal is judged as it is typed, exactly as it is when the details Value field is
-        // the one being typed in.
         updateValueValidation(entry->getType(), newText);
     }
+}
+
+void AttributePage::onEditorClosed(void)
+{
+    onCurCellChanged(mList->ctrlTableList()->currentItem(), nullptr);
 }
 
 void AttributePage::refreshAll(void)

--- a/sources/lusan/view/common/AttributePage.hpp
+++ b/sources/lusan/view/common/AttributePage.hpp
@@ -180,6 +180,10 @@ protected slots:
     //!< before the list is rebuilt underneath it.
     void onEditorDataChanged(const QModelIndex& index, const QString& newValue);
 
+    //!< Mirrors the name being typed in a list cell into the details panel, leaving the inline
+    //!< editor open; the rename itself commits once, through onEditorDataChanged.
+    void onEditorTextChanged(const QModelIndex& index, const QString& newText);
+
     //!< Rebuilds the whole list on any Attribute-kind notifier signal.
     void onNotifierChanged(void);
 

--- a/sources/lusan/view/common/AttributePage.hpp
+++ b/sources/lusan/view/common/AttributePage.hpp
@@ -180,9 +180,12 @@ protected slots:
     //!< before the list is rebuilt underneath it.
     void onEditorDataChanged(const QModelIndex& index, const QString& newValue);
 
-    //!< Mirrors the name being typed in a list cell into the details panel, leaving the inline
-    //!< editor open; the rename itself commits once, through onEditorDataChanged.
+    //!< Mirrors the name or value being typed in a list cell into the details panel, leaving the
+    //!< inline editor open; the edit itself commits once, through onEditorDataChanged.
     void onEditorTextChanged(const QModelIndex& index, const QString& newText);
+
+    //!< Fills the details panel from the model once an inline editor has closed.
+    void onEditorClosed(void);
 
     //!< Rebuilds the whole list on any Attribute-kind notifier signal.
     void onNotifierChanged(void);

--- a/sources/lusan/view/common/ConstantPage.cpp
+++ b/sources/lusan/view/common/ConstantPage.cpp
@@ -130,7 +130,9 @@ void ConstantPage::buildUi(const QString& headline)
     // Name, type and value are editable in the list as well as in the details panel, so a row can
     // be filled in without leaving the keyboard.
     QTreeWidget* table = mList->ctrlTableList();
-    mTableCell = new TableCell(QList<QAbstractItemModel*>{ mTypeNames }, QList<int>{ static_cast<int>(eColumn::ColType) }, table, this, false);
+    // The inline editors commit when the edit is done, not per keystroke: a commit rebuilds the
+    // list, which would tear the open editor down after the first character typed.
+    mTableCell = new TableCell(QList<QAbstractItemModel*>{ mTypeNames }, QList<int>{ static_cast<int>(eColumn::ColType) }, table, this, true);
     mTableCell->setColumnValidation(static_cast<int>(eColumn::ColName), TableCell::eCellValidation::Identifier);
     table->setItemDelegateForColumn(static_cast<int>(eColumn::ColName) , mTableCell);
     table->setItemDelegateForColumn(static_cast<int>(eColumn::ColType) , mTableCell);
@@ -169,6 +171,9 @@ void ConstantPage::setupSignals(void)
 
     // A commit from an inline editor rebuilds the list. Let the delegate close first.
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &ConstantPage::onEditorDataChanged, Qt::QueuedConnection);
+    // Live-preview the name typed in a list cell into the details Name field, the mirror image of
+    // what the details field does to the list row. It commits nothing, so the editor stays open.
+    connect(mTableCell, &TableCell::signalEditorTextChanged, this, &ConstantPage::onEditorTextChanged);
 
     // The shared view already installs the C++ identifier validator on the Name field.
     connect(mDetails->ctrlName()   , &QLineEdit::editingFinished    , this, &ConstantPage::onNameCommitted);
@@ -673,6 +678,22 @@ void ConstantPage::onEditorDataChanged(const QModelIndex& index, const QString& 
 
     // The commit above rebuilt the list; put the details panel back on the edited row.
     selectConstant(id);
+}
+
+void ConstantPage::onEditorTextChanged(const QModelIndex& index, const QString& newText)
+{
+    QTreeWidget* table = mList->ctrlTableList();
+    QTreeWidgetItem* item = table->topLevelItem(index.row());
+    if ((index.column() != static_cast<int>(eColumn::ColName))
+        || (item == nullptr) || (item != table->currentItem()))
+    {
+        return;
+    }
+
+    // Blocked: the field re-emits its text as nameEdited, which would write it straight back into
+    // the row whose editor is open.
+    const QSignalBlocker blockName(mDetails->ctrlName());
+    mDetails->ctrlName()->setText(newText);
 }
 
 void ConstantPage::refreshAll(void)

--- a/sources/lusan/view/common/ConstantPage.cpp
+++ b/sources/lusan/view/common/ConstantPage.cpp
@@ -171,19 +171,11 @@ void ConstantPage::setupSignals(void)
 
     // A commit from an inline editor rebuilds the list. Let the delegate close first.
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &ConstantPage::onEditorDataChanged, Qt::QueuedConnection);
-    // Live-preview what is typed in a list cell into the matching details field, the mirror image
-    // of what the details fields do to the list row. It commits nothing, so the editor stays open.
     connect(mTableCell, &TableCell::signalEditorTextChanged, this, &ConstantPage::onEditorTextChanged);
-    // An edit can end without committing anything: an emptied cell is refused, and Escape cancels.
-    // Rebuilding once the editor is gone puts the row and the previewed details back to what the
-    // model actually holds. Queued, so the view has finished with the editor, and so a commit that
-    // is on its way is applied on top.
-    connect(mTableCell, &QAbstractItemDelegate::closeEditor, this, [this]() { refreshAll(); }, Qt::QueuedConnection);
+    connect(mTableCell, &TableCell::signalEditorClosed     , this, &ConstantPage::onEditorClosed);
 
     // The shared view already installs the C++ identifier validator on the Name field.
     connect(mDetails->ctrlName()   , &QLineEdit::editingFinished    , this, &ConstantPage::onNameCommitted);
-    // Live-preview the typed name into the selected constant's Name column; the rename commits
-    // on editingFinished. Selection sets the field under a QSignalBlocker.
     connect(mDetails                , &ConstantDetailsView::nameEdited, this, [this](const QString& text) {
         if (currentConstantId() != 0)
         {
@@ -692,13 +684,9 @@ void ConstantPage::onEditorTextChanged(const QModelIndex& index, const QString& 
     if ((item == nullptr) || (item != table->currentItem()))
         return;
 
-    // The row itself is deliberately left alone: writing to the cell under an open editor makes
-    // the view re-seed that editor from the cell, which would wipe what is being typed. The
-    // editor covers the cell anyway, so only the details panel has anything to show.
     if (index.column() == static_cast<int>(eColumn::ColName))
     {
-        // Blocked: the field re-emits its text as nameEdited, which would write it straight back
-        // into the row whose editor is open.
+        // Blocked: the field re-emits its text as nameEdited, which writes it back into the row.
         const QSignalBlocker blockName(mDetails->ctrlName());
         mDetails->ctrlName()->setText(newText);
     }
@@ -710,10 +698,13 @@ void ConstantPage::onEditorTextChanged(const QModelIndex& index, const QString& 
 
         const QSignalBlocker blockValue(mDetails->ctrlValue());
         mDetails->ctrlValue()->setText(newText);
-        // The literal is judged as it is typed, exactly as it is when the details Value field is
-        // the one being typed in.
         updateValueValidation(entry->getType(), newText);
     }
+}
+
+void ConstantPage::onEditorClosed(void)
+{
+    onCurCellChanged(mList->ctrlTableList()->currentItem(), nullptr);
 }
 
 void ConstantPage::refreshAll(void)

--- a/sources/lusan/view/common/ConstantPage.cpp
+++ b/sources/lusan/view/common/ConstantPage.cpp
@@ -171,9 +171,14 @@ void ConstantPage::setupSignals(void)
 
     // A commit from an inline editor rebuilds the list. Let the delegate close first.
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &ConstantPage::onEditorDataChanged, Qt::QueuedConnection);
-    // Live-preview the name typed in a list cell into the details Name field, the mirror image of
-    // what the details field does to the list row. It commits nothing, so the editor stays open.
+    // Live-preview what is typed in a list cell into the matching details field, the mirror image
+    // of what the details fields do to the list row. It commits nothing, so the editor stays open.
     connect(mTableCell, &TableCell::signalEditorTextChanged, this, &ConstantPage::onEditorTextChanged);
+    // An edit can end without committing anything: an emptied cell is refused, and Escape cancels.
+    // Rebuilding once the editor is gone puts the row and the previewed details back to what the
+    // model actually holds. Queued, so the view has finished with the editor, and so a commit that
+    // is on its way is applied on top.
+    connect(mTableCell, &QAbstractItemDelegate::closeEditor, this, [this]() { refreshAll(); }, Qt::QueuedConnection);
 
     // The shared view already installs the C++ identifier validator on the Name field.
     connect(mDetails->ctrlName()   , &QLineEdit::editingFinished    , this, &ConstantPage::onNameCommitted);
@@ -684,16 +689,31 @@ void ConstantPage::onEditorTextChanged(const QModelIndex& index, const QString& 
 {
     QTreeWidget* table = mList->ctrlTableList();
     QTreeWidgetItem* item = table->topLevelItem(index.row());
-    if ((index.column() != static_cast<int>(eColumn::ColName))
-        || (item == nullptr) || (item != table->currentItem()))
-    {
+    if ((item == nullptr) || (item != table->currentItem()))
         return;
-    }
 
-    // Blocked: the field re-emits its text as nameEdited, which would write it straight back into
-    // the row whose editor is open.
-    const QSignalBlocker blockName(mDetails->ctrlName());
-    mDetails->ctrlName()->setText(newText);
+    // The row itself is deliberately left alone: writing to the cell under an open editor makes
+    // the view re-seed that editor from the cell, which would wipe what is being typed. The
+    // editor covers the cell anyway, so only the details panel has anything to show.
+    if (index.column() == static_cast<int>(eColumn::ColName))
+    {
+        // Blocked: the field re-emits its text as nameEdited, which would write it straight back
+        // into the row whose editor is open.
+        const QSignalBlocker blockName(mDetails->ctrlName());
+        mDetails->ctrlName()->setText(newText);
+    }
+    else if (index.column() == static_cast<int>(eColumn::ColValue))
+    {
+        const ConstantEntry* entry = mModel.findConstant(currentConstantId());
+        if (entry == nullptr)
+            return;
+
+        const QSignalBlocker blockValue(mDetails->ctrlValue());
+        mDetails->ctrlValue()->setText(newText);
+        // The literal is judged as it is typed, exactly as it is when the details Value field is
+        // the one being typed in.
+        updateValueValidation(entry->getType(), newText);
+    }
 }
 
 void ConstantPage::refreshAll(void)

--- a/sources/lusan/view/common/ConstantPage.hpp
+++ b/sources/lusan/view/common/ConstantPage.hpp
@@ -188,9 +188,12 @@ protected slots:
     //!< before the list is rebuilt underneath it.
     void onEditorDataChanged(const QModelIndex& index, const QString& newValue);
 
-    //!< Mirrors the name being typed in a list cell into the details panel, leaving the inline
-    //!< editor open; the rename itself commits once, through onEditorDataChanged.
+    //!< Mirrors the name or value being typed in a list cell into the details panel, leaving the
+    //!< inline editor open; the edit itself commits once, through onEditorDataChanged.
     void onEditorTextChanged(const QModelIndex& index, const QString& newText);
+
+    //!< Fills the details panel from the model once an inline editor has closed.
+    void onEditorClosed(void);
 
     //!< Rebuilds the whole list on any Constant-kind notifier signal.
     void onNotifierChanged(void);

--- a/sources/lusan/view/common/ConstantPage.hpp
+++ b/sources/lusan/view/common/ConstantPage.hpp
@@ -188,6 +188,10 @@ protected slots:
     //!< before the list is rebuilt underneath it.
     void onEditorDataChanged(const QModelIndex& index, const QString& newValue);
 
+    //!< Mirrors the name being typed in a list cell into the details panel, leaving the inline
+    //!< editor open; the rename itself commits once, through onEditorDataChanged.
+    void onEditorTextChanged(const QModelIndex& index, const QString& newText);
+
     //!< Rebuilds the whole list on any Constant-kind notifier signal.
     void onNotifierChanged(void);
 

--- a/sources/lusan/view/common/DataTypePage.cpp
+++ b/sources/lusan/view/common/DataTypePage.cpp
@@ -234,6 +234,8 @@ void DataTypePage::setupSignals(void)
 
     // A commit from an inline editor rebuilds the tree. Let the delegate close first.
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &DataTypePage::onEditorDataChanged, Qt::QueuedConnection);
+    connect(mTableCell, &TableCell::signalEditorTextChanged, this, &DataTypePage::onEditorTextChanged);
+    connect(mTableCell, &TableCell::signalEditorClosed     , this, &DataTypePage::onEditorClosed);
 
     // The identifier validator is installed inside the shared DataTypeDetailsView.
     connect(mDetails->ctrlName()            , &QLineEdit::editingFinished      , this, &DataTypePage::onNameCommitted);
@@ -1624,6 +1626,49 @@ void DataTypePage::onEditorDataChanged(const QModelIndex& index, const QString& 
 
     // The commit above rebuilt the tree; put the details panel back on the edited row.
     selectDataType(dataType->getId(), fieldId);
+}
+
+void DataTypePage::onEditorTextChanged(const QModelIndex& index, const QString& newText)
+{
+    DataTypeCustom* dataType = currentDataType();
+    if (dataType == nullptr)
+        return;
+
+    const uint32_t fieldId = currentFieldId();
+    const int column = index.column();
+    if (fieldId == 0)
+    {
+        if (column == static_cast<int>(eColumn::ColName))
+        {
+            // Blocked: the field mirrors its text back into the row whose editor is open.
+            const QSignalBlocker blockName(mDetails->ctrlName());
+            mDetails->ctrlName()->setText(newText);
+        }
+    }
+    else if (column == static_cast<int>(eColumn::ColName))
+    {
+        const QSignalBlocker blockName(mFields->ctrlName());
+        mFields->ctrlName()->setText(newText);
+    }
+    else if (column == static_cast<int>(eColumn::ColValue))
+    {
+        const QSignalBlocker blockValue(mFields->ctrlValue());
+        mFields->ctrlValue()->setText(newText);
+
+        if (dataType->getCategory() == DataTypeBase::eCategory::Structure)
+        {
+            const FieldEntry* field = static_cast<DataTypeStructure*>(dataType)->findElement(fieldId);
+            if (field != nullptr)
+            {
+                mFields->showValueHint(validateFieldValue(field->getType(), newText));
+            }
+        }
+    }
+}
+
+void DataTypePage::onEditorClosed(void)
+{
+    onCurCellChanged(mList->ctrlTableList()->currentItem(), nullptr);
 }
 
 void DataTypePage::applyCellEdit(DataTypeCustom* dataType, uint32_t fieldId, int column, const QString& newValue)

--- a/sources/lusan/view/common/DataTypePage.hpp
+++ b/sources/lusan/view/common/DataTypePage.hpp
@@ -173,6 +173,13 @@ protected slots:
     //!< before the tree is rebuilt underneath it.
     void onEditorDataChanged(const QModelIndex& index, const QString& newValue);
 
+    //!< Mirrors the name or value being typed in a tree cell into the details panel, leaving the
+    //!< inline editor open; the edit itself commits once, through onEditorDataChanged.
+    void onEditorTextChanged(const QModelIndex& index, const QString& newText);
+
+    //!< Fills the details panel from the model once an inline editor has closed.
+    void onEditorClosed(void);
+
     //!< Rebuilds the whole tree on any DataType-kind notifier signal.
     void onNotifierChanged(void);
 

--- a/sources/lusan/view/common/IncludePage.cpp
+++ b/sources/lusan/view/common/IncludePage.cpp
@@ -190,6 +190,8 @@ void IncludePage::setupSignals(void)
     mDetails->ctrlDescription()->installEventFilter(this);
 
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &IncludePage::onInlineLocationEdited);
+    connect(mTableCell, &TableCell::signalEditorTextChanged, this, &IncludePage::onInlineLocationTyped);
+    connect(mTableCell, &TableCell::signalEditorClosed     , this, &IncludePage::onEditorClosed);
 
     DocModelNotifier& notifier = mModel.getNotifier();
 
@@ -503,6 +505,24 @@ void IncludePage::onLocationTextChanged(const QString& text)
     item->setText(static_cast<int>(IncludeListView::eColumn::ColType)    , mList->typeForLocation(text));
     item->setText(static_cast<int>(IncludeListView::eColumn::ColName)    , mList->nameForLocation(text));
     mList->ctrlTableList()->setCurrentItem(item);
+}
+
+void IncludePage::onInlineLocationTyped(const QModelIndex& index, const QString& newText)
+{
+    if (index.column() != static_cast<int>(IncludeListView::eColumn::ColLocation))
+        return;
+
+    if (currentIncludeId() != 0)
+    {
+        // Blocked: the field mirrors its text back into the row whose editor is open.
+        const QSignalBlocker blockInclude(mDetails->ctrlInclude());
+        mDetails->ctrlInclude()->setText(newText);
+    }
+}
+
+void IncludePage::onEditorClosed(void)
+{
+    onCurCellChanged(mList->ctrlTableList()->currentItem(), nullptr);
 }
 
 void IncludePage::onInlineLocationEdited(const QModelIndex& index, const QString& newValue)

--- a/sources/lusan/view/common/IncludePage.hpp
+++ b/sources/lusan/view/common/IncludePage.hpp
@@ -166,6 +166,13 @@ protected slots:
     //!< Type/Name columns then refresh from the notifier. Escape is handled by the delegate.
     void onInlineLocationEdited(const QModelIndex& index, const QString& newValue);
 
+    //!< Mirrors the path being typed in a list cell into the details panel, leaving the inline
+    //!< editor open; the edit itself commits once, through onInlineLocationEdited.
+    void onInlineLocationTyped(const QModelIndex& index, const QString& newText);
+
+    //!< Fills the details panel from the model once an inline editor has closed.
+    void onEditorClosed(void);
+
     void onBrowseClicked(void);
     void onDeprecatedToggled(bool checked);
     void onDeprecateHintCommitted(void);

--- a/sources/lusan/view/common/MethodPage.cpp
+++ b/sources/lusan/view/common/MethodPage.cpp
@@ -308,6 +308,8 @@ void MethodPage::setupSignals(void)
         table->setItemDelegateForColumn(col, mTableCell);
     }
     connect(mTableCell, &TableCell::signalEditorDataChanged, this, &MethodPage::onEditorDataChanged);
+    connect(mTableCell, &TableCell::signalEditorTextChanged, this, &MethodPage::onEditorTextChanged);
+    connect(mTableCell, &TableCell::signalEditorClosed     , this, &MethodPage::onEditorClosed);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1528,6 +1530,35 @@ void MethodPage::onEditorDataChanged(const QModelIndex& index, const QString& ne
     {
         commitInlineEdit(kind, methodId, paramId, col, newValue);
     }, Qt::QueuedConnection);
+}
+
+void MethodPage::onEditorTextChanged(const QModelIndex& index, const QString& newText)
+{
+    const eRowKind kind = currentKind();
+    const int column = index.column();
+    if ((kind == eRowKind::Method) && (column == static_cast<int>(MethodListView::ColName)))
+    {
+        const QSignalBlocker blockName(mDetails->ctrlName());
+        mDetails->ctrlName()->setText(newText);
+    }
+    else if (kind == eRowKind::Param)
+    {
+        if (column == static_cast<int>(MethodListView::ColName))
+        {
+            const QSignalBlocker blockName(mParamDetails->ctrlName());
+            mParamDetails->ctrlName()->setText(newText);
+        }
+        else if (column == static_cast<int>(MethodListView::ColValue))
+        {
+            const QSignalBlocker blockValue(mParamDetails->ctrlValue());
+            mParamDetails->ctrlValue()->setText(newText);
+        }
+    }
+}
+
+void MethodPage::onEditorClosed(void)
+{
+    onCurCellChanged(mList->ctrlTableList()->currentItem(), nullptr);
 }
 
 void MethodPage::commitInlineEdit(int kind, uint32_t methodId, uint32_t paramId, int column, const QString& newValue)

--- a/sources/lusan/view/common/MethodPage.hpp
+++ b/sources/lusan/view/common/MethodPage.hpp
@@ -223,6 +223,13 @@ protected slots:
     //!< before the tree is rebuilt underneath it.
     void onEditorDataChanged(const QModelIndex& index, const QString& newValue);
 
+    //!< Mirrors the name or value being typed in a tree cell into the details panel, leaving the
+    //!< inline editor open; the edit itself commits once, through onEditorDataChanged.
+    void onEditorTextChanged(const QModelIndex& index, const QString& newText);
+
+    //!< Fills the details panel from the model once an inline editor has closed.
+    void onEditorClosed(void);
+
 //////////////////////////////////////////////////////////////////////////
 // Hidden methods
 //////////////////////////////////////////////////////////////////////////

--- a/sources/lusan/view/common/TableCell.cpp
+++ b/sources/lusan/view/common/TableCell.cpp
@@ -39,7 +39,6 @@ TableCell::TableCell(QWidget* parent, IETableHelper * tableHelper, bool waitEndE
     , mEditable ( )
     , mModelOf  ( )
     , mValidOf  ( )
-    , mParent   (parent)
     , mTable    (tableHelper)
     , mWaitEnd  (waitEndEdit)
     , mNewText  ( )
@@ -58,14 +57,12 @@ TableCell::TableCell(const QList<QAbstractItemModel*>& models, const QList<int>&
     , mEditable ( )
     , mModelOf  ( )
     , mValidOf  ( )
-    , mParent   (parent)
     , mTable    (tableHelper)
     , mWaitEnd  (waitEndEdit)
     , mNewText  ( )
     , mSelIndex ( )
     , mEditOriginal( )
 {
-    // Escape cancels the edit: the view reports RevertModelCache when the editor closes.
     connect(this, &QAbstractItemDelegate::closeEditor, this, &TableCell::onCloseEditor);
 
     Q_ASSERT(models.size() == columns.size());
@@ -110,22 +107,6 @@ inline bool TableCell::isValidColumn(int col) const
     return (col >= 0) && (col < mTable->getColumnCount());
 }
 
-bool TableCell::isComboWidget(int col) const
-{
-    if (isValidColumn(col))
-    {
-        for (int i = 0; i < static_cast<int>(mColumns.size()); ++i)
-        {
-            if (mColumns[i] == col)
-            {
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
-
 QAbstractItemModel* TableCell::columnToModel(int col) const
 {
     if (isValidColumn(col))
@@ -148,23 +129,18 @@ QWidget* TableCell::createEditor(QWidget* parent, const QStyleOptionViewItem& /*
     mSelIndex = QModelIndex();
     mEditOriginal.clear();
 
-    // A heterogeneous tree (e.g. Data Types) suppresses editing on cells that make no sense for
-    // the row's category; when no predicate is set every valid cell stays editable.
     if (mEditable && (mEditable(index) == false))
     {
         return nullptr;
     }
 
-    // The per-cell resolver wins over the per-column model list, so one column can be a combo for
-    // some rows (struct field type) and a text editor for others (imported type, enum derived).
     QAbstractItemModel* model = mModelOf ? mModelOf(index) : columnToModel(index.column());
     if (model != nullptr)
     {
         QComboBox* combo = new QComboBox(parent);
         combo->setModel(model);
         combo->setProperty("index", index);
-        // The platform drop-down inherits the cell width and elides entries such as "uint32_t", so
-        // the popup view is widened to its longest item.
+        // The drop-down inherits the cell width and elides its entries, so it is widened here.
         if (QAbstractItemView* popup = combo->view())
         {
             popup->setTextElideMode(Qt::ElideNone);
@@ -174,8 +150,8 @@ QWidget* TableCell::createEditor(QWidget* parent, const QStyleOptionViewItem& /*
                 popup->setMinimumWidth(hint + 24);
             }
         }
-        // Commit only on user activation, never on currentTextChanged: a programmatic
-        // setCurrentText() in setEditorData() would commit stale text over the user's choice.
+
+        // Commit only on user activation, never on currentTextChanged.
         connect(combo, &QComboBox::activated, this, &TableCell::onComboActivated);
 
         return combo;
@@ -183,14 +159,10 @@ QWidget* TableCell::createEditor(QWidget* parent, const QStyleOptionViewItem& /*
     else if ( isValidColumn(index.column()) )
     {
         QLineEdit* lineEdit = new QLineEdit(parent);
-        // The index must travel with the editor so the change routes back to the correct
-        // row/column (a missing property yields an invalid index that is silently dropped).
+        // The index travels with the editor. Without it the change routes nowhere and is dropped.
         lineEdit->setProperty("index", index);
-        // Remember the committed cell text so Escape can restore it (see onCloseEditor). In live
-        // mode every keystroke has already been applied, so the original is the only way back.
+        // The committed text, for the rollback an Escape needs.
         mEditOriginal = mTable->getCellText(index);
-        // Forbid invalid characters directly in the table, matching the details panel. The
-        // per-cell resolver wins so the same column can validate differently by row category.
         const eCellValidation kind = mValidOf ? mValidOf(index) : mValidation.value(index.column(), eCellValidation::NoValidation);
         switch (kind)
         {
@@ -224,8 +196,7 @@ QWidget* TableCell::createEditor(QWidget* parent, const QStyleOptionViewItem& /*
 
 void TableCell::setEditorData(QWidget* editor, const QModelIndex& index) const
 {
-    // Key off the actual editor type, not the per-column registration: a combo may now be
-    // produced by the per-cell resolver on a column that is not in the combo-column list.
+    // Keyed off the editor type: the resolver can put a combo on any column.
     if (QComboBox* combo = qobject_cast<QComboBox*>(editor))
     {
         if (index.data(Qt::EditRole).isNull())
@@ -243,9 +214,8 @@ void TableCell::updateEditorGeometry(QWidget* editor, const QStyleOptionViewItem
 {
     if (editor != nullptr)
     {
-        // A flat list row is often shorter than a comfortable edit control, so the editor grows
-        // vertically (centered on the cell). Its width stays inside the cell: anything wider
-        // covers the first characters of the neighbouring column while the edit is open.
+        // The editor grows vertically, centered on the cell. Its width stays inside the cell:
+        // anything wider covers the neighbouring column while the edit is open.
         QRect rect = option.rect;
         const int minHeight = qMax(editor->sizeHint().height(), 24);
         if (rect.height() < minHeight)
@@ -266,8 +236,7 @@ void TableCell::onComboActivated(int /*index*/)
     QComboBox* combo = qobject_cast<QComboBox*>(sender());
     if (combo != nullptr)
     {
-        // Route the choice through the same signal the line editor uses, then dismiss the drop-down.
-        // The owning controller updates the model, so the base setModelData() stays uncalled.
+        // The owning page updates the model, so the base setModelData() stays uncalled.
         emit signalEditorDataChanged(combo->property("index").toModelIndex(), combo->currentText());
         emit closeEditor(combo);
     }
@@ -279,8 +248,6 @@ void TableCell::onEditorTextChanged(const QString & newText)
     if (editor != nullptr)
     {
         const QModelIndex index = editor->property("index").toModelIndex();
-        // A preview of what the editor holds, for a page that mirrors the cell elsewhere while
-        // the edit is still open. It commits nothing, so the editor is never closed underneath.
         emit signalEditorTextChanged(index, newText);
 
         if (mWaitEnd == false)
@@ -297,7 +264,8 @@ void TableCell::onEditorTextChanged(const QString & newText)
 
 void TableCell::onEditorTextChangeFinished()
 {
-    if (mWaitEnd && mSelIndex.isValid() && (mNewText.isEmpty() == false))
+    // An emptied cell is a text edit like any other; the page decides whether it is allowed.
+    if (mWaitEnd && mSelIndex.isValid())
     {
         emit signalEditorDataChanged(mSelIndex, mNewText);
         mSelIndex = QModelIndex();
@@ -307,23 +275,28 @@ void TableCell::onEditorTextChangeFinished()
 
 void TableCell::onCloseEditor(QWidget* editor, QAbstractItemDelegate::EndEditHint hint)
 {
-    // Only Escape (cancel) is handled here; a normal commit closes the editor with a different
-    // hint and its value has already been routed through signalEditorDataChanged.
-    if (hint != QAbstractItemDelegate::RevertModelCache)
+    if (qobject_cast<QLineEdit*>(editor) == nullptr)
         return;
 
-    // Drop any pending wait-for-end text so the queued editingFinished (fired as the editor loses
-    // focus while it is being torn down) cannot commit the cancelled value.
-    const QModelIndex index = (editor != nullptr) ? editor->property("index").toModelIndex() : QModelIndex();
-    mSelIndex = QModelIndex();
-    mNewText.clear();
-
-    // In live mode every keystroke updated the model, cell and details panel, so replay the
-    // pre-edit value through the same path. Wait-for-end mode committed nothing.
-    if ((mWaitEnd == false) && (qobject_cast<QLineEdit*>(editor) != nullptr) && index.isValid())
+    const QModelIndex index = editor->property("index").toModelIndex();
+    if (hint == QAbstractItemDelegate::RevertModelCache)
     {
-        emit signalEditorDataChanged(index, mEditOriginal);
+        // Escape. Drop the pending text before the lost focus turns it into a commit.
+        mSelIndex = QModelIndex();
+        mNewText.clear();
+
+        // Live mode already applied every keystroke, so the pre-edit value is replayed.
+        if ((mWaitEnd == false) && index.isValid())
+        {
+            emit signalEditorDataChanged(index, mEditOriginal);
+        }
     }
 
     mEditOriginal.clear();
+
+    // Queued, so a commit that the closing editor still has to report is dispatched first.
+    if (index.isValid())
+    {
+        QMetaObject::invokeMethod(this, [this]() { emit signalEditorClosed(); }, Qt::QueuedConnection);
+    }
 }

--- a/sources/lusan/view/common/TableCell.cpp
+++ b/sources/lusan/view/common/TableCell.cpp
@@ -318,17 +318,9 @@ void TableCell::onCloseEditor(QWidget* editor, QAbstractItemDelegate::EndEditHin
     mSelIndex = QModelIndex();
     mNewText.clear();
 
-    const bool isLineEdit = (qobject_cast<QLineEdit*>(editor) != nullptr);
-
-    // Put back whatever a page mirrored from the keystrokes it previewed.
-    if (isLineEdit && index.isValid())
-    {
-        emit signalEditorTextChanged(index, mEditOriginal);
-    }
-
     // In live mode every keystroke updated the model, cell and details panel, so replay the
     // pre-edit value through the same path. Wait-for-end mode committed nothing.
-    if ((mWaitEnd == false) && isLineEdit && index.isValid())
+    if ((mWaitEnd == false) && (qobject_cast<QLineEdit*>(editor) != nullptr) && index.isValid())
     {
         emit signalEditorDataChanged(index, mEditOriginal);
     }

--- a/sources/lusan/view/common/TableCell.cpp
+++ b/sources/lusan/view/common/TableCell.cpp
@@ -278,14 +278,19 @@ void TableCell::onEditorTextChanged(const QString & newText)
     QWidget *editor = qobject_cast<QWidget *>(sender());
     if (editor != nullptr)
     {
+        const QModelIndex index = editor->property("index").toModelIndex();
+        // A preview of what the editor holds, for a page that mirrors the cell elsewhere while
+        // the edit is still open. It commits nothing, so the editor is never closed underneath.
+        emit signalEditorTextChanged(index, newText);
+
         if (mWaitEnd == false)
         {
-            emit signalEditorDataChanged(editor->property("index").toModelIndex(), newText);
+            emit signalEditorDataChanged(index, newText);
         }
         else
         {
             mNewText = newText;
-            mSelIndex = editor->property("index").toModelIndex();
+            mSelIndex = index;
         }
     }
 }
@@ -313,9 +318,17 @@ void TableCell::onCloseEditor(QWidget* editor, QAbstractItemDelegate::EndEditHin
     mSelIndex = QModelIndex();
     mNewText.clear();
 
+    const bool isLineEdit = (qobject_cast<QLineEdit*>(editor) != nullptr);
+
+    // Put back whatever a page mirrored from the keystrokes it previewed.
+    if (isLineEdit && index.isValid())
+    {
+        emit signalEditorTextChanged(index, mEditOriginal);
+    }
+
     // In live mode every keystroke updated the model, cell and details panel, so replay the
     // pre-edit value through the same path. Wait-for-end mode committed nothing.
-    if ((mWaitEnd == false) && (qobject_cast<QLineEdit*>(editor) != nullptr) && index.isValid())
+    if ((mWaitEnd == false) && isLineEdit && index.isValid())
     {
         emit signalEditorDataChanged(index, mEditOriginal);
     }

--- a/sources/lusan/view/common/TableCell.hpp
+++ b/sources/lusan/view/common/TableCell.hpp
@@ -236,16 +236,21 @@ signals:
     void signalEditorDataChanged(const QModelIndex &index, const QString &newValue);
 
     /**
-     * \brief   The signal is triggered on every keystroke of an open line editor, reporting the
-     *          text it holds right now. It is a preview and not a commit: the owning page mirrors
-     *          the text into its details panel while the editor stays open, and the model is
-     *          updated only when signalEditorDataChanged arrives. A page that previews must put
-     *          its panel right from the model when the editor closes, since an edit that ends
-     *          empty or is cancelled commits nothing at all.
+     * \brief   The signal is triggered on every keystroke of an open line editor and reports the
+     *          text the editor holds. It previews the edit and commits nothing, so the editor
+     *          stays open; the model is updated when signalEditorDataChanged arrives.
      * \param   index       The index of the table cell being edited.
      * \param   newText     The text currently in the editor.
+     * \note    A page that mirrors the preview into a details panel restores that panel from the
+     *          model on signalEditorClosed, because an edit can end without committing anything.
      **/
     void signalEditorTextChanged(const QModelIndex &index, const QString &newText);
+
+    /**
+     * \brief   The signal is triggered after a line editor of a table cell has closed, and after
+     *          the commit it produced, if any, has been dispatched.
+     **/
+    void signalEditorClosed(void);
 
 //////////////////////////////////////////////////////////////////////////
 // Slots
@@ -295,12 +300,6 @@ private:
     bool isValidColumn(int col) const;
 
     /**
-     * \brief   Returns true if the given column index is a combo box widget.
-     * \param   col     The column index.
-     **/
-    bool isComboWidget(int col) const;
-
-    /**
      * \brief   Returns the model of the given column.
      * \param   col     The column index.
      * \return  Returns the model of the given column.
@@ -317,7 +316,6 @@ private:
     FuncEditable                mEditable;  //!< Optional per-cell editability predicate (heterogeneous trees).
     FuncEditorModel             mModelOf;   //!< Optional per-cell combo-model resolver (overrides mColumns).
     FuncValidation              mValidOf;   //!< Optional per-cell validation resolver (overrides mValidation).
-    QWidget *                   mParent;    //!< The parent table widget.
     IETableHelper*              mTable;     //!< The table helper object to validate the data.
     bool                        mWaitEnd;   //!< Wait for end of editing. Valid only for line editor, no relevant to combobox.
     mutable QString             mNewText;   //!< The changed text.

--- a/sources/lusan/view/common/TableCell.hpp
+++ b/sources/lusan/view/common/TableCell.hpp
@@ -239,8 +239,9 @@ signals:
      * \brief   The signal is triggered on every keystroke of an open line editor, reporting the
      *          text it holds right now. It is a preview and not a commit: the owning page mirrors
      *          the text into its details panel while the editor stays open, and the model is
-     *          updated only when signalEditorDataChanged arrives. On Escape the signal is emitted
-     *          once more with the pre-edit text, so the preview is put back.
+     *          updated only when signalEditorDataChanged arrives. A page that previews must put
+     *          its panel right from the model when the editor closes, since an edit that ends
+     *          empty or is cancelled commits nothing at all.
      * \param   index       The index of the table cell being edited.
      * \param   newText     The text currently in the editor.
      **/

--- a/sources/lusan/view/common/TableCell.hpp
+++ b/sources/lusan/view/common/TableCell.hpp
@@ -234,7 +234,18 @@ signals:
      * \param   newValue    The new value of the table cell.
      **/
     void signalEditorDataChanged(const QModelIndex &index, const QString &newValue);
-    
+
+    /**
+     * \brief   The signal is triggered on every keystroke of an open line editor, reporting the
+     *          text it holds right now. It is a preview and not a commit: the owning page mirrors
+     *          the text into its details panel while the editor stays open, and the model is
+     *          updated only when signalEditorDataChanged arrives. On Escape the signal is emitted
+     *          once more with the pre-edit text, so the preview is put back.
+     * \param   index       The index of the table cell being edited.
+     * \param   newText     The text currently in the editor.
+     **/
+    void signalEditorTextChanged(const QModelIndex &index, const QString &newText);
+
 //////////////////////////////////////////////////////////////////////////
 // Slots
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #490

## Summary

Typing a name directly in the Attributes or Constants list dropped out of edit mode
after the first character. Both pages built their inline-editor delegate in live mode,
so every keystroke committed a rename to the model; the commit pushed an undo command,
the notifier fired `elementChanged`, and the page rebuilt its list. The rebuild clears
the tree, which destroys the very item the inline editor is attached to.

The name can now be typed continuously, and each character still reaches the Details
panel immediately.

## Changes

- `TableCell` gains `signalEditorTextChanged`, emitted on every keystroke of an open
  line editor. It is a preview and not a commit, so nothing rebuilds the list while the
  editor is open. On Escape it is emitted once more with the pre-edit text, so a page
  that mirrored the keystrokes puts its preview back.
- `AttributePage` and `ConstantPage` now construct `TableCell` with `waitEndEdit = true`,
  the mode the Methods, Includes and Data Types pages already use: the rename is
  committed once, on editing-finished, as a single undo step instead of one per
  character.
- Both pages mirror the previewed name into the Details Name field, the mirror image of
  the existing `nameEdited` path that mirrors the Details field into the list row.

Unchanged: the Type and Notification cells commit through `onComboActivated`, which does
not depend on `waitEndEdit`, so Service Interface notification types and State Machine
initial values behave exactly as before. The shared pages cover the Service Interface,
State Machine and Data Type documents, so all three are fixed by the same change.

## Testing

- Building requires Qt 6.x, which was not available on my machine, so the change was not
  compiled locally — the CI matrix (Windows/MSVC + Qt 6.8, Linux + Qt 6.8, Linux + Qt 6.4,
  macOS + Qt 6.11) covers that.
- Reviewed `tests/common/DesignPageTests.cpp`: `exercisePage()` drives the Details name
  field and `pickInCell()` drives combo cells, neither of which touches the changed
  inline line-editor path, so no existing assertion is affected and no test needed
  changing. The undo-step count it asserts is unchanged.
- The `waitEndEdit = true` + queued-commit combination introduced here is already in
  production use by `DataTypePage`.

A quick manual pass on the Attributes and Constants pages of a Service Interface and a
State Machine would be appreciated before merge.
